### PR TITLE
Change `max_length` dynamically for fast inference

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -207,7 +207,10 @@ def evaluate(
             if description_dict and task_name in description_dict
             else ""
         )
-
+        # set tokenizer inside task 
+        if task.LOAD_TOKENIZER:
+            task.set_tokenizer(lm.tokenizer)
+        
         for doc_id, doc in enumerate(itertools.islice(task_docs, 0, limit)):
 
             if decontaminate and task.should_decontaminate():

--- a/lm_eval/tasks/jsquad.py
+++ b/lm_eval/tasks/jsquad.py
@@ -12,7 +12,6 @@ from math import exp
 from lm_eval.base import rf, Task
 from functools import partial
 
-
 _CITATION = """
 @inproceedings{kurihara-etal-2022-jglue,
     title = "{JGLUE}: {J}apanese General Language Understanding Evaluation",
@@ -52,6 +51,7 @@ class JSQuAD(Task):
     PROMPT_VERSION = 0.1
     DATASET_PATH = "shunk031/JGLUE"
     DATASET_NAME = "JSQuAD"
+    LOAD_TOKENIZER = True
     DESCRIPTION = "[題名]と[問題]から[質問]に対する[答え]を抜き出しなさい\n\n"
     SEP = "\n"
     REMOVE_IDS = []
@@ -124,7 +124,8 @@ class JSQuAD(Task):
         return answer
 
     def construct_requests(self, doc, ctx):
-        continuation = rf.greedy_until(ctx, [self.SEP])
+        max_num_tokens = max([len(self.tokenizer.encode(answer, add_special_tokens=False)) for answer in doc["answers"]["text"]])
+        continuation = rf.greedy_until(ctx, [self.SEP], max_num_tokens)
         return continuation
 
     def process_results(self, doc, results):


### PR DESCRIPTION
## Background

**Current Issue**

- In question answering tasks such as JSQuAD, models generate predicted answers by greedy sampling
- While sampling, generate tokens until a given stop token (eg. `\n`) or the number of generated tokens is less than `max_new_tokens` ([the parameter is defined in a `max_gen_toks` function](https://github.com/Stability-AI/lm-evaluation-harness/blob/jp-stable/lm_eval/models/gpt2.py#L82) in lm-eval-harness)
- When the model has good capabilities of in-context learning, the generation would stop by a given stop token. BUT, if not, the model generates tokens until `max_new_tokens`, which is generally big such as 256
- It leads to slow inference.

**Solution**

- set `max_new_tokens` to the max tokens inside gold answers

## What's changed
* Allow task classes to access tokenizer when `LOAD_TOKENIZER=True`.
* Allow to pass `max_new_tokens` to greedy_until
* Introduce an env variable `DYNAMIC_MAX_LENGTH` (default: `true`) to change it by users

## Results

| base_model | task | num_fewshot | dynamic | Inference time\* |
| :--: | :--: | :--: | :--: | :--: |
| rinna-gpt-1b | jsquad-1.1-0.1 | 2 | NO | 6 hours |
| rinna-gpt-1b | jsquad-1.1-0.1 | 2 | **YES** | 10 mins 🔥 |
* \* on a 40GB GPU machine 
* ⚠️ The results between w/ dynamic change and w/o it are much different. So, when you compare scores of JSQuAD/JaQuAD, please make sure to compute them w/ same algorithm. (If scores are computed in a same branch, that would be okay. )