### PR TITLE
Add JNLI

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -55,6 +55,7 @@ from . import crowspairs
 from . import jsquad
 from . import jaquad
 from . import jcommonsenseqa
+from . import jnli
 
 ########################################
 # Translation tasks
@@ -320,6 +321,8 @@ TASK_REGISTRY = {
     **jaquad.construct_tasks(),
     "jcommonsenseqa": jcommonsenseqa.JCommonsenseQA,
     **jcommonsenseqa.construct_tasks(),
+    "jnli": jnli.JNLIWithFintanPrompt,
+    **jnli.construct_tasks(),
 }
 
 

--- a/lm_eval/tasks/jnli.py
+++ b/lm_eval/tasks/jnli.py
@@ -38,8 +38,8 @@ class JNLIWithFintanPrompt(MultipleChoiceTask):
     DATASET_NAME = "JNLI"
     DESCRIPTION = "前提と仮説の関係をentailment、contradiction、neutralの中から回答してください。\n\n" + \
         "制約:\n" + \
-        "- 前提から仮説が、論理的知識や常識的知識を用いて導出可能である場合はentailmentと出力" + \
-        "- 前提と仮説が両立しえない場合はcontradictionと出力" + \
+        "- 前提から仮説が、論理的知識や常識的知識を用いて導出可能である場合はentailmentと出力\n" + \
+        "- 前提と仮説が両立しえない場合はcontradictionと出力\n" + \
         "- そのいずれでもない場合はneutralと出力\n\n"
     CHOICES = ["entailment", "contradiction", "neutral"]
 
@@ -87,6 +87,8 @@ class JNLIWithFintanPrompt(MultipleChoiceTask):
         lls = [
             rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
         ]
+
+
 
         return lls
 

--- a/lm_eval/tasks/jnli.py
+++ b/lm_eval/tasks/jnli.py
@@ -1,0 +1,102 @@
+"""
+JGLUE: Japanese General Language Understanding Evaluation
+https://aclanthology.org/2022.lrec-1.317/
+
+JGLUE, Japanese General Language Understanding Evaluation, is built to measure the general NLU ability in Japanese. 
+JGLUE has been constructed from scratch without translation. 
+
+Homepage: https://github.com/yahoojapan/JGLUE
+"""
+from lm_eval.base import MultipleChoiceTask, rf
+
+_CITATION = """
+@inproceedings{kurihara-etal-2022-jglue,
+    title = "{JGLUE}: {J}apanese General Language Understanding Evaluation",
+    author = "Kurihara, Kentaro  and
+      Kawahara, Daisuke  and
+      Shibata, Tomohide",
+    booktitle = "Proceedings of the Thirteenth Language Resources and Evaluation Conference",
+    month = jun,
+    year = "2022",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://aclanthology.org/2022.lrec-1.317",
+    pages = "2957--2966",
+    abstract = "To develop high-performance natural language understanding (NLU) models, it is necessary to have a benchmark to evaluate and analyze NLU ability from various perspectives. While the English NLU benchmark, GLUE, has been the forerunner, benchmarks are now being released for languages other than English, such as CLUE for Chinese and FLUE for French; but there is no such benchmark for Japanese. We build a Japanese NLU benchmark, JGLUE, from scratch without translation to measure the general NLU ability in Japanese. We hope that JGLUE will facilitate NLU research in Japanese.",
+}
+"""
+
+
+
+class JNLIWithFintanPrompt(MultipleChoiceTask):
+    """
+    prompt template is taken from [ChatGPT vs BERT: どちらが日本語をより理解できるのか?](https://fintan.jp/page/9126/)
+    """
+    VERSION = 1.1
+    PROMPT_VERSION = 0.2
+    DATASET_PATH = "shunk031/JGLUE"
+    DATASET_NAME = "JNLI"
+    DESCRIPTION = "前提と仮説の関係をentailment、contradiction、neutralの中から回答してください。\n\n" + \
+        "制約:\n" + \
+        "- 前提から仮説が、論理的知識や常識的知識を用いて導出可能である場合はentailmentと出力" + \
+        "- 前提と仮説が両立しえない場合はcontradictionと出力" + \
+        "- そのいずれでもない場合はneutralと出力\n\n"
+    CHOICES = ["entailment", "contradiction", "neutral"]
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(map(self._process_doc, self.dataset["train"]))
+        return self._training_docs
+
+    def validation_docs(self):
+        return map(self._process_doc, self.dataset["validation"])
+
+    def _process_doc(self, doc):
+        return {
+            "premise": doc["sentence1"],
+            "hypothesis": doc["sentence2"],
+            "choices": self.CHOICES,
+            "gold": int(doc["label"]), 
+        }
+
+    def doc_to_text(self, doc):
+        """
+        前提:{premise}
+        仮説:{hypothesis}
+        関係:
+        """
+        return (
+            f"前提:{doc['premise']}\n"
+            f"仮説:{doc['hypothesis']}\n"
+            "関係:"
+        )
+
+    def doc_to_target(self, doc):
+        return doc["choices"][doc["gold"]]
+
+    def construct_requests(self, doc, ctx):
+        lls = [
+            rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
+        ]
+
+        return lls
+
+VERSIONS = [
+    JNLIWithFintanPrompt,
+]
+
+
+def construct_tasks():
+    tasks = {}
+    for version_class in VERSIONS:
+        tasks[f"jnli-{version_class.VERSION}-{version_class.PROMPT_VERSION}"] = version_class
+    return tasks


### PR DESCRIPTION
## What's changed
* Add [JNLI from JGLUE](https://github.com/yahoojapan/JGLUE/tree/main/datasets/jnli-v1.1) with [Fintan's prompt template](https://fintan.jp/page/9126/)

## Usage
```bash
MODEL_ARGS="pretrained=rinna/japanese-gpt-1b,use_fast=False"
TASK="jnli"
python main.py \
    --model hf-causal \
    --model_args $MODEL_ARGS \
    --tasks $TASK \
    --num_fewshot "3"
```