### PR TITLE
Add MARC-ja

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -55,6 +55,7 @@ from . import crowspairs
 from . import jsquad
 from . import jaquad
 from . import jcommonsenseqa
+from . import marc_ja
 
 ########################################
 # Translation tasks
@@ -320,6 +321,8 @@ TASK_REGISTRY = {
     **jaquad.construct_tasks(),
     "jcommonsenseqa": jcommonsenseqa.JCommonsenseQA,
     **jcommonsenseqa.construct_tasks(),
+    "marc_ja": marc_ja.MARCJaWithFintanPrompt,
+    **marc_ja.construct_tasks(),
 }
 
 

--- a/lm_eval/tasks/marc_ja.py
+++ b/lm_eval/tasks/marc_ja.py
@@ -1,0 +1,95 @@
+"""
+JGLUE: Japanese General Language Understanding Evaluation
+https://aclanthology.org/2022.lrec-1.317/
+
+JGLUE, Japanese General Language Understanding Evaluation, is built to measure the general NLU ability in Japanese. 
+JGLUE has been constructed from scratch without translation. 
+
+Homepage: https://github.com/yahoojapan/JGLUE
+"""
+from lm_eval.base import MultipleChoiceTask, rf
+
+_CITATION = """
+@inproceedings{kurihara-etal-2022-jglue,
+    title = "{JGLUE}: {J}apanese General Language Understanding Evaluation",
+    author = "Kurihara, Kentaro  and
+      Kawahara, Daisuke  and
+      Shibata, Tomohide",
+    booktitle = "Proceedings of the Thirteenth Language Resources and Evaluation Conference",
+    month = jun,
+    year = "2022",
+    address = "Marseille, France",
+    publisher = "European Language Resources Association",
+    url = "https://aclanthology.org/2022.lrec-1.317",
+    pages = "2957--2966",
+    abstract = "To develop high-performance natural language understanding (NLU) models, it is necessary to have a benchmark to evaluate and analyze NLU ability from various perspectives. While the English NLU benchmark, GLUE, has been the forerunner, benchmarks are now being released for languages other than English, such as CLUE for Chinese and FLUE for French; but there is no such benchmark for Japanese. We build a Japanese NLU benchmark, JGLUE, from scratch without translation to measure the general NLU ability in Japanese. We hope that JGLUE will facilitate NLU research in Japanese.",
+}
+"""
+
+
+
+class MARCJaWithFintanPrompt(MultipleChoiceTask):
+    """
+    prompt template is taken from [ChatGPT vs BERT: どちらが日本語をより理解できるのか?](https://fintan.jp/page/9126/)
+    """
+    VERSION = 1.1
+    PROMPT_VERSION = 0.2
+    DATASET_PATH = "shunk031/JGLUE"
+    DATASET_NAME = "MARC-ja"
+    DESCRIPTION = "製品レビューをnegativeかpositiveのいずれかのセンチメントに分類してください。出力は小文字化してください。 \n\n"
+    CHOICES = ["positive", "negative"]
+
+    def has_training_docs(self):
+        return True
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return False
+
+    def training_docs(self):
+        if self._training_docs is None:
+            self._training_docs = list(map(self._process_doc, self.dataset["train"]))
+        return self._training_docs
+
+    def validation_docs(self):
+        return map(self._process_doc, self.dataset["validation"])
+
+    def _process_doc(self, doc):
+        return {
+            "query": doc["sentence"],
+            "choices": self.CHOICES,
+            "gold": int(doc["label"]), 
+        }
+
+    def doc_to_text(self, doc):
+        """
+        製品レビュー:{query}
+        センチメント:
+        """
+        return (
+            f"製品レビュー:{doc['query']}\n"
+            "センチメント:"
+        )
+
+    def doc_to_target(self, doc):
+        return doc["choices"][doc["gold"]]
+
+    def construct_requests(self, doc, ctx):
+        lls = [
+            rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
+        ]
+
+        return lls
+
+VERSIONS = [
+    MARCJaWithFintanPrompt,
+]
+
+
+def construct_tasks():
+    tasks = {}
+    for version_class in VERSIONS:
+        tasks[f"marc_ja-{version_class.VERSION}-{version_class.PROMPT_VERSION}"] = version_class
+    return tasks


### PR DESCRIPTION
## What's changed
* Add [MARC-ja from JGLUE](https://github.com/yahoojapan/JGLUE/tree/main/datasets/marc_ja-v1.1) with [Fintan's prompt template](https://fintan.jp/page/9126/)

## Usage
```bash
MODEL_ARGS="pretrained=rinna/japanese-gpt-1b,use_fast=False"
TASK="marc_ja"
python main.py \
    --model hf-causal \
    --model_args $MODEL_ARGS \
    --tasks $TASK \
    --num_fewshot "3"
```