### PR TITLE
add xlsum_ja

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ For more details, please see [docs/jptasks.md](https://github.com/Stability-AI/l
 
 | Tasks | [Supported Prompt Templates](https://github.com/Stability-AI/lm-evaluation-harness/blob/jp-stable/docs/prompt_templates.md) |
 | :- | -: | 
-| [JSQuAD](#jsquad) | 0.1 / 0.2 / 0.3 / 0.4 |
-| [JCommonsenseQA](#jcommonsenseqa) |  0.1 / 0.2 / 0.3 / 0.4 |
-| [JNLI](#jnli) | 0.2 / 0.3 / 0.4 |
-| [MARC-ja](#marc-ja) | 0.2 / 0.3 / 0.4 |
-| [JaQuAD](#jaquad) | 0.1 / 0.2 / 0.3 / 0.4 |
-| [JBLiMP](#jblimp) | - |
-
+| JSQuAD | 0.1 / 0.2 / 0.3 / 0.4 |
+| JCommonsenseQA |  0.1 / 0.2 / 0.3 / 0.4 |
+| JNLI | 0.2 / 0.3 / 0.4 |
+| MARC-ja | 0.2 / 0.3 / 0.4 |
+| JaQuAD | 0.1 / 0.2 / 0.3 / 0.4 |
+| JBLiMP | - |
+| XLSum-ja | 0.0 / 0.3 / 0.4 |
 -----------------
 # Language Model Evaluation Harness
 

--- a/docs/jptasks.md
+++ b/docs/jptasks.md
@@ -84,3 +84,26 @@ python main.py \
     --num_fewshot "0" \
     --output_path "result.json"
 ```
+
+## [XLSum-ja](https://huggingface.co/datasets/csebuetnlp/xlsum)
+This is a filtered Japanese subset of [XLSum](https://huggingface.co/datasets/csebuetnlp/xlsum) based on ROUGE-2, where [PaLM 2](https://arxiv.org/abs/2305.10403) uses. 
+
+**main features**
+- Filtered data based on 15-gram overlap as PaLM 2 did.
+  - link to dataset: https://huggingface.co/datasets/mkshing/xlsum_ja
+  - link to script: https://gist.github.com/mkshing/d6371cbfdd50d4f352cee247fd4dd86a
+- Compute ROUGE-2 based on Mecab Tokenizer
+
+**sample scripts**
+
+```
+python main.py \
+    --model hf-causal \
+    --model_args $MODEL_ARGS \
+    --tasks "xlsum_ja" \
+    --num_fewshot "1" \
+    --output_path "result.json"
+```
+
+* \* 1-shot setting In [PaLM 2](https://arxiv.org/abs/2305.10403)
+

--- a/docs/prompt_templates.md
+++ b/docs/prompt_templates.md
@@ -1,5 +1,5 @@
 # Prompt Templates
-For JGLUE metrics, you can choose suitable prompt template for your model. 
+Before evaluation, you can choose suitable prompt template for your model. 
 
 Once you found the best one of the following supported templates, replace `TEMPLATE` to the template version. 
 
@@ -14,6 +14,10 @@ python main.py \
     --device "cuda" \
     --output_path "result.json"
 ```
+
+## `0.0`
+This version uses plausible prompt templates the contributor made. In most cases, templates in paper are well-investigated so that they should be good to use. But, the reality is that some eval tasks we want to support are never used before. In this case, the contributors would carefully think of the plausible prompt template as this version.
+
 
 ## `0.1`
 - **Reference:** [日本語に特化した60億パラメータ規模のGPTモデルの構築と評価](https://www.anlp.jp/proceedings/annual_meeting/2023/pdf_dir/H9-4.pdf)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -222,6 +222,9 @@ def evaluate(
                 task.set_tokenizer(lm.lm.tokenizer)
             else:
                 task.set_tokenizer(lm.tokenizer)
+        # set max_length to task object
+        task.max_length = lm.lm.max_length if isinstance(lm, lm_eval.base.CachingLM) else lm.max_length
+        task.max_gen_toks = lm.lm.max_gen_toks if isinstance(lm, lm_eval.base.CachingLM) else lm.max_gen_toks
         
         limit_local = limit[idx]
         if isinstance(limit_local, float):

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -58,6 +58,7 @@ from .ja import jcommonsenseqa
 from .ja import jnli
 from .ja import marc_ja
 from .ja import jblimp
+from .ja import xlsum_ja
 ########################################
 # Translation tasks
 ########################################
@@ -327,6 +328,8 @@ TASK_REGISTRY = {
     "marc_ja": marc_ja.MARCJaWithFintanPrompt,
     **marc_ja.construct_tasks(),
     "jblimp": jblimp.JBlimp,
+    "xlsum_ja": xlsum_ja.XLSumJa,
+    **xlsum_ja.construct_tasks(),
 }
 
 

--- a/lm_eval/tasks/ja/__init__.py
+++ b/lm_eval/tasks/ja/__init__.py
@@ -1,0 +1,34 @@
+import re
+
+
+class MecabTokenizer:
+    def __init__(self) -> None:
+        from fugashi import Tagger
+        self.tagger = Tagger('-Owakati')
+
+    def normalize_answer(self, text):
+        """Lower text and remove punctuation, articles and extra whitespace."""
+        import emoji
+        import neologdn
+
+        def white_space_fix(text):
+            return " ".join(text.split())
+        
+        def remove_emoji(text):
+            text = "".join(["" if emoji.is_emoji(c) else c for c in text])
+            emoji_pattern = re.compile(
+                "["
+                u"\U0001F600-\U0001F64F"  # emoticons
+                u"\U0001F300-\U0001F5FF"  # symbols & pictographs
+                u"\U0001F680-\U0001F6FF"  # transport & map symbols
+                u"\U0001F1E0-\U0001F1FF"  # flags (iOS)
+                u"\U00002702-\U000027B0"
+                "]+",
+                flags=re.UNICODE,
+            )
+            return emoji_pattern.sub(r"", text)
+        
+        return white_space_fix((neologdn.normalize(remove_emoji(text))))
+
+    def tokenize(self, text):
+        return self.tagger.parse(self.normalize_answer(text)).split()

--- a/lm_eval/tasks/ja/__init__.py
+++ b/lm_eval/tasks/ja/__init__.py
@@ -7,7 +7,7 @@ class MecabTokenizer:
         self.tagger = Tagger('-Owakati')
 
     def normalize_answer(self, text):
-        """Lower text and remove punctuation, articles and extra whitespace."""
+        """Lower case text, remove punctuation and extra whitespace, etc."""
         import emoji
         import neologdn
 

--- a/lm_eval/tasks/ja/__init__.py
+++ b/lm_eval/tasks/ja/__init__.py
@@ -28,7 +28,11 @@ class MecabTokenizer:
             )
             return emoji_pattern.sub(r"", text)
         
-        return white_space_fix((neologdn.normalize(remove_emoji(text))))
+        text = remove_emoji(text)
+        # see neologdn docs for details, but handles things like full/half width variation
+        text = neologdn.normalize(text)
+        text = white_space_fix(text)
+        return text
 
     def tokenize(self, text):
         return self.tagger.parse(self.normalize_answer(text)).split()

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -1,0 +1,167 @@
+"""
+XL-Sum: Large-Scale Multilingual Abstractive Summarization for 44 Languages
+https://aclanthology.org/2021.findings-acl.413/
+
+We present XLSum, a comprehensive and diverse dataset comprising 1.35 million professionally annotated article-summary pairs from BBC, extracted using a set of carefully designed heuristics. 
+The dataset covers 45 languages ranging from low to high-resource, for many of which no public dataset is currently available. 
+XL-Sum is highly abstractive, concise, and of high quality, as indicated by human and intrinsic evaluation. 
+
+Homepage: https://github.com/csebuetnlp/xl-sum
+"""
+from rouge_score import rouge_scorer, scoring
+from lm_eval.base import rf, Task
+
+
+_CITATION = """
+@inproceedings{hasan-etal-2021-xl,
+    title = "{XL}-Sum: Large-Scale Multilingual Abstractive Summarization for 44 Languages",
+    author = "Hasan, Tahmid  and
+      Bhattacharjee, Abhik  and
+      Islam, Md. Saiful  and
+      Mubasshir, Kazi  and
+      Li, Yuan-Fang  and
+      Kang, Yong-Bin  and
+      Rahman, M. Sohel  and
+      Shahriyar, Rifat",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL-IJCNLP 2021",
+    month = aug,
+    year = "2021",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2021.findings-acl.413",
+    doi = "10.18653/v1/2021.findings-acl.413",
+    pages = "4693--4703",
+}
+"""
+
+
+class XLSumJa(Task):
+    """ 
+    - Use ROUGE-2 as [PaLM 2](https://ai.google/static/documents/palm2techreport.pdf)
+    - Use Mecab tokenizer for Japanese eval 
+    """
+    VERSION = 0
+    # this prompt was made by mkshing
+    PROMPT_VERSION = 0.0
+    DATASET_PATH = "mkshing/xlsum_ja"
+    DATASET_NAME = None
+    DESCRIPTION = "与えられたニュース記事を要約してください。\n\n"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        from . import MecabTokenizer
+        self.tokenizer = MecabTokenizer()
+
+    def has_training_docs(self):
+        return False
+
+    def has_validation_docs(self):
+        return True
+
+    def has_test_docs(self):
+        return True
+    
+    def training_docs(self):
+        return self.dataset["train"]
+
+    def validation_docs(self):
+        return self.dataset["validation"]
+    
+    def test_docs(self):
+        return self.dataset["test"]
+
+    def doc_to_text(self, doc):
+        return f"ニュース記事:{doc['text']}\n要約:"
+
+    def doc_to_target(self, doc):
+        return doc["summary"]
+
+    def construct_requests(self, doc, ctx):
+        completion = rf.greedy_until(ctx, ["\n"])
+        return completion
+
+    def process_results(self, doc, results):
+        continuation = results[0]
+        ground_truth = doc["summary"]
+        return {
+            "rouge2": (
+                continuation,
+                ground_truth,
+            )
+        }
+    
+    def aggregation(self):
+        return {
+            "rouge2": self._rouge
+        }
+
+    def higher_is_better(self):
+        return {
+            "rouge2": True,
+        }
+    
+    def _rouge(self, item):
+        predictions, references = zip(*item)
+        return self.rouge(refs=references, preds=predictions)["rouge2"]
+
+    def rouge(self, refs, preds):
+        rouge_types = ["rouge2"]
+        # mecab-based rouge 
+        scorer = rouge_scorer.RougeScorer(
+            rouge_types,
+            tokenizer=self.tokenizer,
+        )
+
+        # Accumulate confidence intervals.
+        aggregator = scoring.BootstrapAggregator()
+        for ref, pred in zip(refs, preds):
+            aggregator.add_scores(scorer.score(ref, pred))
+        result = aggregator.aggregate()
+        return {type: result[type].mid.fmeasure * 100 for type in rouge_types}
+
+
+class XLSumJaWithJAAlpacaPrompt(XLSumJa):
+    PROMPT_VERSION = 0.3
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
+    INSTRUCTION = "与えられたニュース記事を要約してください。\n\n"
+    def doc_to_text(self, doc):
+        """
+        以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。
+
+        ### 指示: 
+        {instruction}
+
+        ### 入力: 
+        {input}
+
+        ### 応答: 
+        {response}
+        """
+        input_text = f"ニュース記事:{doc['text']}"
+        return f"### 指示:\n{self.INSTRUCTION}\n\n### 入力:\n{input_text}\n\n### 応答:\n"
+
+
+class XLSumJaWithRinnaInstructionSFT(XLSumJa):
+    """
+    Reference:
+    - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
+    """
+    PROMPT_VERSION = 0.4
+    DESCRIPTION = "ユーザー: 与えられたニュース記事を要約してください。<NL>システム: 分かりました。"
+    def doc_to_text(self, doc):
+        input_text = f"ニュース記事:{doc['text']}"
+        return f"<NL>ユーザー: {input_text}<NL>システム: "
+
+
+VERSIONS = [
+    XLSumJa,
+    XLSumJaWithJAAlpacaPrompt,
+    XLSumJaWithRinnaInstructionSFT,
+]
+
+
+def construct_tasks():
+    tasks = {}
+    for version_class in VERSIONS:
+        tasks[f"xlsum_ja-{version_class.VERSION}-{version_class.PROMPT_VERSION}"] = version_class
+    return tasks

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import logging
@@ -106,6 +107,7 @@ def main():
     print(dumped)
 
     if args.output_path:
+        os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
         with open(args.output_path, "w") as f:
             f.write(dumped)
 

--- a/models/abeja-gpt-neox-japanese-2.7b/harness.sh
+++ b/models/abeja-gpt-neox-japanese-2.7b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=abeja/gpt-neox-japanese-2.7b"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/abeja-gpt-neox-japanese-2.7b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/abeja-gpt-neox-japanese-2.7b/result.json"

--- a/models/abeja-gpt-neox-japanese-2.7b/result.json
+++ b/models/abeja-gpt-neox-japanese-2.7b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 13.665015758667266,
       "f1": 22.909453892411364
+    },
+    "xlsum_ja": {
+      "rouge2": 6.149952794206885
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/cyberagent/cyberagent-open-calm-1b/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-1b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-1b"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/cyberagent-open-calm-1b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-1b/result.json"

--- a/models/cyberagent/cyberagent-open-calm-1b/result.json
+++ b/models/cyberagent/cyberagent-open-calm-1b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 37.12291760468258,
       "f1": 47.171446643186265
+    },
+    "xlsum_ja": {
+      "rouge2": 2.288077088085482
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/cyberagent/cyberagent-open-calm-3b/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-3b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-3b"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/cyberagent-open-calm-3b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-3b/result.json"

--- a/models/cyberagent/cyberagent-open-calm-3b/result.json
+++ b/models/cyberagent/cyberagent-open-calm-3b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 41.647906348491674,
       "f1": 53.3615935638234
+    },
+    "xlsum_ja": {
+      "rouge2": 2.043355220946065
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/cyberagent/cyberagent-open-calm-7b/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-7b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-7b"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/cyberagent-open-calm-7b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-7b/result.json"

--- a/models/cyberagent/cyberagent-open-calm-7b/result.json
+++ b/models/cyberagent/cyberagent-open-calm-7b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 48.176497073390365,
       "f1": 61.04446929428723
+    },
+    "xlsum_ja": {
+      "rouge2": 2.0395791206778204
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/cyberagent/cyberagent-open-calm-large/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-large/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-large,use_fast=True"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/cyberagent-open-calm-large/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-large/result.json"

--- a/models/cyberagent/cyberagent-open-calm-large/result.json
+++ b/models/cyberagent/cyberagent-open-calm-large/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 37.23547951373255,
       "f1": 48.50349592141573
+    },
+    "xlsum_ja": {
+      "rouge2": 1.9854375467671679
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/cyberagent/cyberagent-open-calm-medium/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-medium/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-medium,use_fast=True"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/cyberagent-open-calm-medium/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-medium/result.json"

--- a/models/cyberagent/cyberagent-open-calm-medium/result.json
+++ b/models/cyberagent/cyberagent-open-calm-medium/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 28.725799189554255,
       "f1": 39.80333448254385
+    },
+    "xlsum_ja": {
+      "rouge2": 2.5775988917922406
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-1b/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-1b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-1b,use_fast=False"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/rinna-japanese-gpt-1b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-1b/result.json"

--- a/models/rinna/rinna-japanese-gpt-1b/result.json
+++ b/models/rinna/rinna-japanese-gpt-1b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 28.072940117064384,
       "f1": 45.44848667804334
+    },
+    "xlsum_ja": {
+      "rouge2": 5.4305544197428235
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-ppo,use_fast=False"
-TASK="jsquad-1.1-0.4,jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.4": {
       "exact_match": 53.42188203511932,
       "f1": 64.21204580384475
+    },
+    "xlsum_ja-1.0-0.4": {
+      "rouge2": 6.539218619815743
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.4": 1.1,
     "jnli-1.1-0.4": 1.1,
     "jsquad-1.1-0.4": 1.1,
-    "marc_ja-1.1-0.4": 1.1
+    "marc_ja-1.1-0.4": 1.1,
+    "xlsum_ja-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft-v2,use_fast=False"
-TASK="jsquad-1.1-0.4,jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.4": {
       "exact_match": 45.31742458352094,
       "f1": 59.7296045907487
+    },
+    "xlsum_ja-1.0-0.4": {
+      "rouge2": 6.198010013992279
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.4": 1.1,
     "jnli-1.1-0.4": 1.1,
     "jsquad-1.1-0.4": 1.1,
-    "marc_ja-1.1-0.4": 1.1
+    "marc_ja-1.1-0.4": 1.1,
+    "xlsum_ja-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft,use_fast=False"
-TASK="jsquad-1.1-0.4,jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.4": {
       "exact_match": 47.321026564610534,
       "f1": 61.35722982692858
+    },
+    "xlsum_ja-1.0-0.4": {
+      "rouge2": 4.354465926425856
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.4": 1.1,
     "jnli-1.1-0.4": 1.1,
     "jsquad-1.1-0.4": 1.1,
-    "marc_ja-1.1-0.4": 1.1
+    "marc_ja-1.1-0.4": 1.1,
+    "xlsum_ja-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b,use_fast=False"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-python main.py     --model hf-causal     --model_args $MODEL_ARGS     --tasks $TASK     --num_fewshot "2,3,3,3"     --device "cuda"     --output_path "models/rinna-japanese-gpt-neox-3.6b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b/result.json
@@ -21,13 +21,17 @@
     "jsquad-1.1-0.2": {
       "exact_match": 50.29266096352994,
       "f1": 61.107638748126
+    },
+    "xlsum_ja": {
+      "rouge2": 5.17647093477623
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "marc_ja-1.1-0.2": 1.1
+    "marc_ja-1.1-0.2": 1.1,
+    "xlsum_ja": 1.0
   },
   "config": {
     "model": "hf-causal",
@@ -36,7 +40,8 @@
       2,
       3,
       3,
-      3
+      3,
+      1
     ],
     "batch_size": null,
     "device": "cuda",


### PR DESCRIPTION
## Description
related: https://www.notion.so/stabilityai/Consider-XLSum-13e12b678c2b47408951d9e04515c056?pvs=4

* Add a filtered Japanese subset of [XLSum](https://huggingface.co/datasets/csebuetnlp/xlsum) based on ROUGE-2, where [PaLM 2](https://arxiv.org/abs/2305.10403) uses. 
  * Introduce ROUGE-2 based on Mecab Tokenizer
  * Filtered data based on 15-gram overlap as [PaLM 2](https://arxiv.org/abs/2305.10403) did. 
    * link to dataset: https://huggingface.co/datasets/mkshing/xlsum_ja
    * link to the script: https://gist.github.com/mkshing/d6371cbfdd50d4f352cee247fd4dd86a
* sample scripts
  
  ```
  python main.py \
      --model hf-causal \
      --model_args $MODEL_ARGS \
      --tasks "xlsum_ja" \
      --num_fewshot "1" \
      --output_path "result.json"
  ```


## About XLSum
From [the original dataset](https://huggingface.co/datasets/csebuetnlp/xlsum)
> We present XLSum, a comprehensive and diverse dataset comprising 1.35 million professionally annotated article-summary pairs from BBC, extracted using a set of carefully designed heuristics. The dataset covers 45 languages ranging from low to high-resource, for many of which no public dataset is currently available. XL-Sum is highly abstractive, concise, and of high quality, as indicated by human and intrinsic evaluation. 

From [PaLM 2](https://arxiv.org/abs/2305.10403)
> XLSum (Hasan et al., 2021), which asks a model to summarize a news article in the same language in a single sentence, in Arabic, Bengali, English, Japanese, Indonesian, Swahili, Korean, Russian, Telugu, Thai, and Turkish.


-----
### TODO
- [x] Add the filtered train set 
- [x] Add scores for existing models
- [x] update readme
