### PR TITLE
should preserve the corresponding order of tasks and num_fewshot arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def pattern_match(patterns, source_list):
     for pattern in patterns:
         for matching in fnmatch.filter(source_list, pattern):
             task_names.add(matching)
-    return sorted(list(task_names))
+    return list(task_names)
 
 
 def main():


### PR DESCRIPTION
`main.py` won't preserve corresponding order of `tasks` and `num_fewshot` arguments.
in this PR, `num_fewshot` and `limit` args are provided to each task respecting the order.

if we run `harness.sh` like this:
```
MODEL_ARGS="pretrained=cyberagent/open-calm-1b"
TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja,jaqket_v2-0.1-0.2"
python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1,1" --device "cuda" --output_path "models/cyberagent-open-calm-1b/result.json"
```
we expect that `num_fewshot` is provided each task in the same order as `tasks`.

but, the `harness.sh` results in that the corresponding order of `tasks` and `num_fewshot` won't be preserved like that:
```
{
  "results": {
    "jaqket_v2-0.1-0.2": {
      "exact_match": 2.9116465863453813,
      "f1": 4.696147504882445
    },
    "jsquad-1.1-0.2": {
      "exact_match": 37.12291760468258,
      "f1": 47.16735348285718
    },
    "xlsum_ja": {
      "rouge2": 2.288077088085482
    },
    "jcommonsenseqa-1.1-0.2": {
      "acc": 0.26988382484361034,
      "acc_stderr": 0.013275885907507282,
      "acc_norm": 0.24754244861483468,
      "acc_norm_stderr": 0.01290758346346734
    },
    "jnli-1.1-0.2": {
      "acc": 0.33566146261298274,
      "acc_stderr": 0.00957358086224245,
      "acc_norm": 0.3331963845521775,
      "acc_norm_stderr": 0.009556042193601356
    },
    "marc_ja-1.1-0.2": {
      "acc": 0.8434736469755925,
      "acc_stderr": 0.004832701818807143,
      "acc_norm": 0.8434736469755925,
      "acc_norm_stderr": 0.004832701818807143
    }
  },
  ..
  "config": {
    "model": "hf-causal",
    "model_args": "pretrained=cyberagent/open-calm-1b",
    "num_fewshot": [
      2,
      3,
      3,
      3,
      1,
      1
    ],
  ..
  }
}
```
