### PR TITLE
Fix batch size type in arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def parse_args():
     parser.add_argument("--tasks", default=None, choices=MultiChoice(tasks.ALL_TASKS))
     parser.add_argument("--provide_description", action="store_true")
     parser.add_argument("--num_fewshot", type=str, default="0")
-    parser.add_argument("--batch_size", type=str, default=None)
+    parser.add_argument("--batch_size", type=int, default=None)
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=str, default=None)


### PR DESCRIPTION
`gpt2.py` contains an [assertion](https://github.com/Stability-AI/lm-evaluation-harness/blob/daba75c0c30e8abcd3ab833ab8fa6f2e426d9f59/lm_eval/models/gpt2.py#L25) but this assertion contradicts the type of the batch size argument because it is set to str in `main.py` as https://github.com/Stability-AI/lm-evaluation-harness/blob/daba75c0c30e8abcd3ab833ab8fa6f2e426d9f59/main.py#L36

To fix this problem, this commit modifies the type of batch size: str -> int in arguments.