### PR TITLE
Allow to change fewshot separator 

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -624,9 +624,9 @@ class Task(abc.ABC):
             print(
                 "WARNING: provide_description is deprecated and will be removed in a future version in favor of description_dict"
             )
-
+        DOUBLESEP = "\n\n" if not hasattr(self, "SEP") else f"{self.SEP}{self.SEP}"
         if description:
-            description += "\n\n"
+            description += DOUBLESEP
         elif hasattr(self, "DESCRIPTION"):
             description = self.DESCRIPTION
         else:
@@ -652,13 +652,13 @@ class Task(abc.ABC):
                 fewshotex = [x for x in fewshotex if x != doc][:num_fewshot]
 
             labeled_examples = (
-                "\n\n".join(
+                DOUBLESEP.join(
                     [
                         self.doc_to_text(doc) + self.doc_to_target(doc)
                         for doc in fewshotex
                     ]
                 )
-                + "\n\n"
+                + DOUBLESEP
             )
 
         example = self.doc_to_text(doc)

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -630,6 +630,7 @@ class Task(abc.ABC):
             FEWSHOT_SEP = f"{self.SEP}{self.SEP}"
         else:        
             FEWSHOT_SEP = "\n\n"
+            
         if description:
             description += FEWSHOT_SEP
         elif hasattr(self, "DESCRIPTION"):

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -624,9 +624,14 @@ class Task(abc.ABC):
             print(
                 "WARNING: provide_description is deprecated and will be removed in a future version in favor of description_dict"
             )
-        DOUBLESEP = "\n\n" if not hasattr(self, "SEP") else f"{self.SEP}{self.SEP}"
+        if hasattr(self, "FEWSHOT_SEP"):
+            FEWSHOT_SEP = self.FEWSHOT_SEP
+        elif hasattr(self, "SEP"):
+            FEWSHOT_SEP = f"{self.SEP}{self.SEP}"
+        else:        
+            FEWSHOT_SEP = "\n\n"
         if description:
-            description += DOUBLESEP
+            description += FEWSHOT_SEP
         elif hasattr(self, "DESCRIPTION"):
             description = self.DESCRIPTION
         else:
@@ -652,13 +657,13 @@ class Task(abc.ABC):
                 fewshotex = [x for x in fewshotex if x != doc][:num_fewshot]
 
             labeled_examples = (
-                DOUBLESEP.join(
+                FEWSHOT_SEP.join(
                     [
                         self.doc_to_text(doc) + self.doc_to_target(doc)
                         for doc in fewshotex
                     ]
                 )
-                + DOUBLESEP
+                + FEWSHOT_SEP
             )
 
         example = self.doc_to_text(doc)

--- a/lm_eval/tasks/ja/jaqket_v2.py
+++ b/lm_eval/tasks/ja/jaqket_v2.py
@@ -221,6 +221,7 @@ class JAQKETV2WithRinnaInstructionSFT(JAQKETV2):
     DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>"
     TOP_K_LIMIT = _TOP_K_LIMIT
     SEP = "<NL>"
+    FEWSHOT_SEP = "<NL>"
 
     def doc_to_text(self, doc):
         context = self.SEP.join([ctx for ctx in doc["ctxs"]["text"][:self.TOP_K_LIMIT]])

--- a/lm_eval/tasks/ja/jaqket_v2.py
+++ b/lm_eval/tasks/ja/jaqket_v2.py
@@ -218,12 +218,14 @@ class JAQKETV2WithRinnaInstructionSFT(JAQKETV2):
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
     """
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。"
+    DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>"
     TOP_K_LIMIT = _TOP_K_LIMIT
+    SEP = "<NL>"
+
     def doc_to_text(self, doc):
-        context = "<NL>".join([ctx for ctx in doc["ctxs"]["text"][:self.TOP_K_LIMIT]])
-        input_text = f"文脈：{context}<NL>質問：{doc['question']}"
-        return f"<NL>ユーザー: {input_text}<NL>システム: "
+        context = self.SEP.join([ctx for ctx in doc["ctxs"]["text"][:self.TOP_K_LIMIT]])
+        input_text = f"文脈：{context}{self.SEP}質問：{doc['question']}"
+        return f"ユーザー: {input_text}{self.SEP}システム: "
 
 
 VERSIONS = [

--- a/lm_eval/tasks/ja/jcommonsenseqa.py
+++ b/lm_eval/tasks/ja/jcommonsenseqa.py
@@ -39,7 +39,7 @@ class JCommonsenseQA(MultipleChoiceTask):
     DATASET_PATH = "shunk031/JGLUE"
     DATASET_NAME = "JCommonsenseQA"
     DESCRIPTION = "[問題]に対する[答え]を[選択肢]の中から選んでください。\n\n"
-
+    
     def has_training_docs(self):
         return True
 
@@ -180,11 +180,13 @@ class JCommonsenseQAWithRinnaInstructionSFT(JCommonsenseQA):
     """
     VERSION = 1.1
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: 与えられた選択肢の中から、最適な答えを選んでください。<NL>システム: 分かりました。"
+    DESCRIPTION = "ユーザー: 与えられた選択肢の中から、最適な答えを選んでください。<NL>システム: 分かりました。<NL>"
+    SEP="<NL>"
+
     def doc_to_text(self, doc):
-        choices = "<NL>".join([f"- {choice}" for choice in doc['choices']])
-        input_text = f"質問：{doc['goal']}<NL>" + f"選択肢：<NL>{choices}"
-        return f"<NL>ユーザー: {input_text}<NL>システム: "
+        choices = self.SEP.join([f"- {choice}" for choice in doc['choices']])
+        input_text = f"質問：{doc['goal']}{self.SEP}" + f"選択肢：{self.SEP}{choices}"
+        return f"ユーザー: {input_text}{self.SEP}システム: "
         
 
 

--- a/lm_eval/tasks/ja/jcommonsenseqa.py
+++ b/lm_eval/tasks/ja/jcommonsenseqa.py
@@ -182,6 +182,7 @@ class JCommonsenseQAWithRinnaInstructionSFT(JCommonsenseQA):
     PROMPT_VERSION = 0.4
     DESCRIPTION = "ユーザー: 与えられた選択肢の中から、最適な答えを選んでください。<NL>システム: 分かりました。<NL>"
     SEP="<NL>"
+    FEWSHOT_SEP = "<NL>"
 
     def doc_to_text(self, doc):
         choices = self.SEP.join([f"- {choice}" for choice in doc['choices']])

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -125,10 +125,11 @@ class JNLIWithRinnaInstructionSFT(JNLIWithFintanPrompt):
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
     """
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: " + f"与えられた前提と仮説の関係を回答してください。出力は以下から選択してください：<NL>" + "<NL>".join(JNLIWithFintanPrompt.CHOICES) + "<NL>システム: 分かりました。"
+    DESCRIPTION = "ユーザー: " + f"与えられた前提と仮説の関係を回答してください。出力は以下から選択してください：<NL>" + "<NL>".join(JNLIWithFintanPrompt.CHOICES) + "<NL>システム: 分かりました。<NL>"
+    SEP = "<NL>"
     def doc_to_text(self, doc):
         input_text = f"前提：{doc['premise']}\n仮説：{doc['hypothesis']}"
-        return f"<NL>ユーザー: {input_text}<NL>システム: "
+        return f"ユーザー: {input_text}{self.SEP}システム: "
    
 
 

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -127,6 +127,8 @@ class JNLIWithRinnaInstructionSFT(JNLIWithFintanPrompt):
     PROMPT_VERSION = 0.4
     DESCRIPTION = "ユーザー: " + f"与えられた前提と仮説の関係を回答してください。出力は以下から選択してください：<NL>" + "<NL>".join(JNLIWithFintanPrompt.CHOICES) + "<NL>システム: 分かりました。<NL>"
     SEP = "<NL>"
+    FEWSHOT_SEP = "<NL>"
+
     def doc_to_text(self, doc):
         input_text = f"前提：{doc['premise']}\n仮説：{doc['hypothesis']}"
         return f"ユーザー: {input_text}{self.SEP}システム: "

--- a/lm_eval/tasks/ja/jsquad.py
+++ b/lm_eval/tasks/ja/jsquad.py
@@ -237,11 +237,12 @@ class JSQuADWithRinnaInstructionSFT(JSQuAD):
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
     """
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。"
+    DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>"
+    SEP = "<NL>"
     def doc_to_text(self, doc):
-        input_text = f"文脈：{doc['context'].split('[SEP]')[-1].strip()}<NL>質問：{doc['question']}"
+        input_text = f"文脈：{doc['context'].split('[SEP]')[-1].strip()}{self.SEP}質問：{doc['question']}"
         # input_text = f"質問：{doc['question']}<NL>文脈：{doc['context'].split('[SEP]')[-1].strip()}"
-        return f"<NL>ユーザー: {input_text}<NL>システム: "
+        return f"ユーザー: {input_text}{self.SEP}システム: "
 
 
 VERSIONS = [

--- a/lm_eval/tasks/ja/jsquad.py
+++ b/lm_eval/tasks/ja/jsquad.py
@@ -239,6 +239,8 @@ class JSQuADWithRinnaInstructionSFT(JSQuAD):
     PROMPT_VERSION = 0.4
     DESCRIPTION = "ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>"
     SEP = "<NL>"
+    FEWSHOT_SEP = "<NL>"
+
     def doc_to_text(self, doc):
         input_text = f"文脈：{doc['context'].split('[SEP]')[-1].strip()}{self.SEP}質問：{doc['question']}"
         # input_text = f"質問：{doc['question']}<NL>文脈：{doc['context'].split('[SEP]')[-1].strip()}"

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -128,12 +128,12 @@ class MARCJaWithRinnaInstructionSFT(MARCJaWithFintanPrompt):
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
     """
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: 与えられた製品レビューを、ポジティブまたはネガティブの感情クラスのいずれかに分類してください。<NL>システム: 分かりました。"    
+    DESCRIPTION = "ユーザー: 与えられた製品レビューを、ポジティブまたはネガティブの感情クラスのいずれかに分類してください。<NL>システム: 分かりました。<NL>"    
     CHOICES = ["ポジティブ", "ネガティブ"]
-
+    SEP = "<NL>"
     def doc_to_text(self, doc):
         input_text = doc['query']
-        return f"<NL>ユーザー: {input_text}<NL>システム: "   
+        return f"ユーザー: {input_text}{self.SEP}システム: "   
 
 
 

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -131,6 +131,8 @@ class MARCJaWithRinnaInstructionSFT(MARCJaWithFintanPrompt):
     DESCRIPTION = "ユーザー: 与えられた製品レビューを、ポジティブまたはネガティブの感情クラスのいずれかに分類してください。<NL>システム: 分かりました。<NL>"    
     CHOICES = ["ポジティブ", "ネガティブ"]
     SEP = "<NL>"
+    FEWSHOT_SEP = "<NL>"
+
     def doc_to_text(self, doc):
         input_text = doc['query']
         return f"ユーザー: {input_text}{self.SEP}システム: "   

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -192,10 +192,12 @@ class XLSumJaWithRinnaInstructionSFT(XLSumJa):
     PROMPT_VERSION = 0.4
     DESCRIPTION = "ユーザー: 与えられたニュース記事を要約してください。<NL>システム: 分かりました。<NL>"
     SEP = "<NL>"
+    FEWSHOT_SEP = "<NL>"
+
     def doc_to_text(self, doc):
         input_text = f"ニュース記事:{doc['text']}"
         return f"ユーザー: {input_text}{self.SEP}システム: "
-
+    
     def preprocess_ctx(self, ctx, max_length):
         return super().preprocess_ctx(ctx, max_length, ctx_prompt=f"{self.SEP}ユーザー: ", summary_prompt=f"{self.SEP}システム: ")
     

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -190,13 +190,14 @@ class XLSumJaWithRinnaInstructionSFT(XLSumJa):
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
     """
     PROMPT_VERSION = 0.4
-    DESCRIPTION = "ユーザー: 与えられたニュース記事を要約してください。<NL>システム: 分かりました。"
+    DESCRIPTION = "ユーザー: 与えられたニュース記事を要約してください。<NL>システム: 分かりました。<NL>"
+    SEP = "<NL>"
     def doc_to_text(self, doc):
         input_text = f"ニュース記事:{doc['text']}"
-        return f"<NL>ユーザー: {input_text}<NL>システム: "
+        return f"ユーザー: {input_text}{self.SEP}システム: "
 
     def preprocess_ctx(self, ctx, max_length):
-        return super().preprocess_ctx(ctx, max_length, ctx_prompt="<NL>ユーザー: ", summary_prompt="<NL>システム: ")
+        return super().preprocess_ctx(ctx, max_length, ctx_prompt=f"{self.SEP}ユーザー: ", summary_prompt=f"{self.SEP}システム: ")
     
     
 VERSIONS = [


### PR DESCRIPTION
## Description
- Fixed an issue reported by @passaglia in [discord](https://discord.com/channels/1062784909191680120/1108193454267318324/1125809316927111240)

> Finally there is a minor issue with the rinna prompt (Prompt 0.4) for all evaluations. Those models do not support the newline character \n and instead use the token <NL>. But newline characters are being inserted in their prompts in base.py here: https://github.com/Stability-AI/lm-evaluation-harness/blob/df5562130fab3627e637104b12edf95dbe3254b8/lm_eval/base.py#L655

- Use `SEP` if task has the attribute

## Example
script
```
MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-ppo,use_fast=False"
TASK="jsquad-1.1-0.4"
python main.py --model hf-causal --model_args $MODEL_ARGS --num_fewshot "2" --device cuda --tasks $TASK
```

before
```
ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>ユーザー: 文脈：メアリー本人の彼女を王位に就けようとする陰謀への加担の真偽は諸説あるが、1571年のリドルフィ陰謀事件から1586年のバビントン陰謀事件までに、エリザベスのスパイ組織のリーダー・フランシス・ウォルシンガムと枢密院は彼女の事件について激しく論議している。当初、エリザベスは彼女の死を求める意見に反対していたが、1586年後半にはバビントン陰謀事件でのメアリーの自筆の手紙の証拠を以って彼女の裁判と処刑に同意させられた。同年11月のエリザベスの判決は「同国王位を僭称するメアリーは同国の共犯者とともに我が国王を傷つけ、殺し、破壊しようと企てた」と宣告した。<NL>質問：リドルフィ陰謀事件は何年？<NL>システム: 1571年

<NL>ユーザー: 文脈：ロボット型検索エンジンは、その原理上インターネット上のコンテンツを複製の上で、検索を目的とした蓄積に適した形態で保存する他、場合によってはキャッシュとして提供できるような形態でも保存する場合がある。著作権をたてに、ウェブサイトの閲覧利用規約等と称して、一切のいかなる複製も禁ずるとするサイト等があり、どういったものかと古くより話題になっていた。<NL>質問：その原理上インターネット上のコンテンツを複製の上で、検索を目的とした蓄積に適した形態で保存する他、場合によってはキャッシュとして提供できるような形態でも保存する場合がある検索エンジンを何と呼ぶ？<NL>システム: ロボット型検索エンジン

<NL>ユーザー: 文脈：2006年秋からチャルマースでは建築家としても土木技師としてもダブルディグリーの機会を提供する新しい教育制度がある。このカリキュラムは建築と技術という名称で、300から360クレジットである。<NL>質問：2006年秋からチャルマースでは建築家としても土木技師としてもダブルディグリーの機会を提供する新しい制度がある。何の制度か？<NL>システム:
```

after 

```
ユーザー: 与えられた文脈から、質問に対する答えを抜き出してください。<NL>システム: 分かりました。<NL>ユーザー: 文脈：メアリー本人の彼女を王位に就けようとする陰謀への加担の真偽は諸説あるが、1571年のリドルフィ陰謀事件から1586年のバビントン陰謀事件までに、エリザベスのスパイ組織のリーダー・フランシス・ウォルシンガムと枢密院は彼女の事件について激しく論議している。当初、エリザベスは彼女の死を求める意見に反対していたが、1586年後半にはバビントン陰謀事件でのメアリーの自筆の手紙の証拠を以って彼女の裁判と処刑に同意させられた。同年11月のエリザベスの判決は「同国王位を僭称するメアリーは同国の共犯者とともに我が国王を傷つけ、殺し、破壊しようと企てた」と宣告した。<NL>質問：リドルフィ陰謀事件は何年？<NL>システム: 1571年<NL><NL>ユーザー: 文脈：ロボット型検索エンジンは、その原理上インターネット上のコンテンツを複製の上で、検索を目的とした蓄積に適した形態で保存する他、場合によってはキャッシュとして提供できるような形態でも保存する場合がある。著作権をたてに、ウェブサイトの閲覧利用規約等と称して、一切のいかなる複製も禁ずるとするサイト等があり、どういったものかと古くより話題になっていた。<NL>質問：その原理上インターネット上のコンテンツを複製の上で、検索を目的とした蓄積に適した形態で保存する他、場合によってはキャッシュとして提供できるような形態でも保存する場合がある検索エンジンを何と呼ぶ？<NL>システム: ロボット型検索エンジン<NL><NL>ユーザー: 文脈：2006年秋からチャルマースでは建築家としても土木技師としてもダブルディグリーの機会を提供する新しい教育制度がある。このカリキュラムは建築と技術という名称で、300から360クレジットである。<NL>質問：2006年秋からチャルマースでは建築家としても土木技師としてもダブルディグリーの機会を提供する新しい制度がある。何の制度か？<NL>システム:

```