### PR TITLE
ja alpaca prompts should include same number of new lines as gpt-neox

### DIFF
--- a/lm_eval/tasks/ja/jaqket_v2.py
+++ b/lm_eval/tasks/ja/jaqket_v2.py
@@ -191,8 +191,8 @@ class JAQKETV2WithJAAlpacaPrompt(JAQKETV2):
     - code: https://github.com/Stability-AI/gpt-neox/blob/c130a4edc1120dccec8f02a34eb60d3e8f484cd3/finetune/finetune_base_ja.py#LL118C23-L127C11
     """
     PROMPT_VERSION = 0.3
-    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
-    INSTRUCTION = "与えられた文脈から、質問に対する答えを抜き出してください。\n\n"
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
+    INSTRUCTION = "与えられた文脈から、質問に対する答えを抜き出してください。"
     TOP_K_LIMIT = _TOP_K_LIMIT
     def doc_to_text(self, doc):
         """

--- a/lm_eval/tasks/ja/jcommonsenseqa.py
+++ b/lm_eval/tasks/ja/jcommonsenseqa.py
@@ -152,7 +152,7 @@ class JCommonsenseQAWithJAAlpacaPrompt(JCommonsenseQA):
     VERSION = 1.1
     PROMPT_VERSION = 0.3
     DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
-    INSTRUCTION = "与えられた選択肢の中から、最適な答えを選んでください。\n\n"
+    INSTRUCTION = "与えられた選択肢の中から、最適な答えを選んでください。"
     def doc_to_text(self, doc):
         """
         以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -98,7 +98,7 @@ class JNLIWithJAAlpacaPrompt(JNLIWithFintanPrompt):
     - code: https://github.com/Stability-AI/gpt-neox/blob/c130a4edc1120dccec8f02a34eb60d3e8f484cd3/finetune/finetune_base_ja.py#LL118C23-L127C11
     """
     PROMPT_VERSION = 0.3
-    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
     INSTRUCTION = f"与えられた前提と仮説の関係を回答してください。\n\n出力は以下から選択してください：\n" + "\n".join(JNLIWithFintanPrompt.CHOICES)
 
     def doc_to_text(self, doc):

--- a/lm_eval/tasks/ja/jsquad.py
+++ b/lm_eval/tasks/ja/jsquad.py
@@ -212,8 +212,8 @@ class JSQuADWithJAAlpacaPrompt(JSQuAD):
     - code: https://github.com/Stability-AI/gpt-neox/blob/c130a4edc1120dccec8f02a34eb60d3e8f484cd3/finetune/finetune_base_ja.py#LL118C23-L127C11
     """
     PROMPT_VERSION = 0.3
-    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
-    INSTRUCTION = "与えられた文脈から、質問に対する答えを抜き出してください。\n\n"
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
+    INSTRUCTION = "与えられた文脈から、質問に対する答えを抜き出してください。"
     def doc_to_text(self, doc):
         """
         以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -100,8 +100,8 @@ class MARCJaWithJAAlpacaPrompt(MARCJaWithFintanPrompt):
     - code: https://github.com/Stability-AI/gpt-neox/blob/c130a4edc1120dccec8f02a34eb60d3e8f484cd3/finetune/finetune_base_ja.py#LL118C23-L127C11
     """
     PROMPT_VERSION = 0.3
-    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
-    INSTRUCTION = "以下の製品レビューを、ポジティブまたはネガティブの感情クラスのいずれかに分類してください。 \n\n"
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
+    INSTRUCTION = "以下の製品レビューを、ポジティブまたはネガティブの感情クラスのいずれかに分類してください。"
     CHOICES = ["ポジティブ", "ネガティブ"]
 
     def doc_to_text(self, doc):

--- a/lm_eval/tasks/ja/mgsm.py
+++ b/lm_eval/tasks/ja/mgsm.py
@@ -130,7 +130,7 @@ class MGSM(GradeSchoolMath8K):
 class MGSMWithJAAlpacaPrompt(MGSM):
     PROMPT_VERSION = 0.3
     DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
-    INSTRUCTION = "与えられた問題に対して、ステップごとに答えを導き出してください。\n\n"
+    INSTRUCTION = "与えられた問題に対して、ステップごとに答えを導き出してください。"
     def doc_to_text(self, doc):
         """
         以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -165,8 +165,8 @@ class XLSumJa(Task):
 
 class XLSumJaWithJAAlpacaPrompt(XLSumJa):
     PROMPT_VERSION = 0.3
-    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n\n"
-    INSTRUCTION = "与えられたニュース記事を要約してください。\n\n"
+    DESCRIPTION = "以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。\n\n"
+    INSTRUCTION = "与えられたニュース記事を要約してください。"
     def doc_to_text(self, doc):
         """
         以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。


### PR DESCRIPTION
This PR corrects number of new lines in JSQuADWithJAAlpacaPrompt and JAQKETV2WithJAAlpacaPrompt.

Based on the comment in the codes, I think the JAAlpacaPrompts should have same number of new lines as the gpt-neox:
https://github.com/Stability-AI/gpt-neox/blob/c130a4edc1120dccec8f02a34eb60d3e8f484cd3/finetune/finetune_base_ja.py#LL118C23-L127C11

But, the prompts have too many new lines currently.
After this PR, the prompts looks like:

```
以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。

## 指示:
与えられた文脈から、質問に対する答えを抜き出してください。

## 入力:
文脈：メアリー本人の彼女を王位に就けようとする陰謀への加担の真偽は諸説あるが、1571年のリドルフィ陰謀事件から1586年のバビントン陰謀事件までに、エリザベスのスパイ組織のリーダー・フランシス・ウォルシンガムと枢密院は彼女の事件について激しく論議している。当初、エリザベスは彼女の死を求める意見に反対していたが、1586年後半にはバビントン陰謀事件でのメアリーの自筆の手紙の証拠を以って彼女の裁判と処刑に同意させられた。同年11月のエリザベスの判決は「同国王位を僭称するメアリーは同国の共犯者とともに我が国王を傷つけ、殺し、破壊しようと企てた」と宣告した。
質問：リドルフィ陰謀事件は何年？

## 応答:
1571年
```

I believe there are other JAAlpacaPrompt such as JCommonsenseQAWithJAAlpacaPrompt to be corrected.
But, I would like to confirm what I raises at first.