### PR TITLE
Fix task ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,11 +49,11 @@ def parse_args():
 # Returns a list containing all values of the source_list that
 # match at least one of the patterns
 def pattern_match(patterns, source_list):
-    task_names = set()
+    task_names = []
     for pattern in patterns:
         for matching in fnmatch.filter(source_list, pattern):
-            task_names.add(matching)
-    return list(task_names)
+            task_names.append(matching)
+    return task_names
 
 
 def main():


### PR DESCRIPTION
This is related to PR https://github.com/Stability-AI/lm-evaluation-harness/pull/37

In main.py, tasks are temporarily stored in a set. Sets do not preserve insertion order. This causes the tasks to fall out of alignment with the num_fewshot list.

Here we fix by storing the tasks in a list.