### PR TITLE
Wont call `to()` if `load_in_8bit` is enabled

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -47,8 +47,12 @@ class HFLM(BaseLM):
             low_cpu_mem_usage=low_cpu_mem_usage,
             revision=revision,
             trust_remote_code=trust_remote_code,
-        ).to(self.device)
-        self.gpt2.eval()
+        ).eval()
+        if not load_in_8bit:
+            try:
+                self.gpt2.to(self.device)
+            except:
+                print("Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes`. If the desired GPU is being used, this message is safe to ignore.")
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(
             pretrained if tokenizer is None else tokenizer,
             revision=revision,

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -215,8 +215,11 @@ class HuggingFaceAutoLM(BaseLM):
             # the user specified one so we force `self._device` to be the same as
             # `lm_head`'s.
             self._device = self.model.hf_device_map["lm_head"]
-        if not use_accelerate:
-            self.model.to(self._device)
+        if not use_accelerate and not load_in_8bit:
+            try:
+                self.model.to(self._device)
+            except:
+                print("Failed to place model onto specified device. This may be because the model is quantized via `bitsandbytes`. If the desired GPU is being used, this message is safe to ignore.")
 
     def _create_auto_model(
         self,


### PR DESCRIPTION
This PR resolves `ValueError` if `load_in_8bit` is enabled.
if you run `harness.sh` with `load_in_8bit=True` in `MODEL_ARGS`, following error is raised:

```
File "/opt/conda/lib/python3.10/site-packages/transformers/modeling_utils.py", line 1897, in to
    raise ValueError(
ValueError: `.to` is not supported for `4-bit` or `8-bit` models.
Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.
```

I've checked transformers repo and it seems to be introduced from [v4.30.0](https://github.com/huggingface/transformers/releases/tag/v4.30.0).
So, I wont call `to()` in gpt2.HFLM initializer if in the case .