### PR TITLE
fix: rename invalid and remove redundant version classes

### DIFF
--- a/lm_eval/tasks/ja/wikilingua.py
+++ b/lm_eval/tasks/ja/wikilingua.py
@@ -133,7 +133,7 @@ class WikilinguaWithJAAlpacaPrompt(Wikilingua):
         return f"### 指示:\n{self.INSTRUCTION}\n\n### 入力:\n{input_text}\n\n### 応答:\n"
 
 
-class WikilinguaJaWithRinnaInstructionSFT(Wikilingua):
+class WikilinguaWithRinnaInstructionSFT(Wikilingua):
     """
     Reference:
     - HF Hub: https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-sft
@@ -154,7 +154,7 @@ class WikilinguaJaWithRinnaInstructionSFT(Wikilingua):
 VERSIONS = [
     Wikilingua,
     WikilinguaWithJAAlpacaPrompt,
-    WikilinguaJaWithRinnaInstructionSFT,
+    WikilinguaWithRinnaInstructionSFT,
 ]
 
 def construct_tasks():

--- a/lm_eval/tasks/ja/wikilingua.py
+++ b/lm_eval/tasks/ja/wikilingua.py
@@ -153,9 +153,8 @@ class WikilinguaJaWithRinnaInstructionSFT(Wikilingua):
 
 VERSIONS = [
     Wikilingua,
-    Wikilingua,
     WikilinguaWithJAAlpacaPrompt,
-    WikilinguaWithRinnaInstructionSFT,
+    WikilinguaJaWithRinnaInstructionSFT,
 ]
 
 def construct_tasks():


### PR DESCRIPTION
With the latest `jp-stable` branch (commit 350304c), I saw the following error:

```
Traceback (most recent call last):
  File "main.py", line 7, in <module>
    from lm_eval import tasks, evaluator
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/tasks/__init__.py", line 61, in <module>
    from .ja import wikilingua
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/tasks/ja/wikilingua.py", line 158, in <module>
    WikilinguaWithRinnaInstructionSFT,
NameError: name 'WikilinguaWithRinnaInstructionSFT' is not defined
```

This seems to be introduced from https://github.com/Stability-AI/lm-evaluation-harness/pull/33