### PR TITLE
bug fix: `ValueError: not enough values to unpack (expected 2, got 1)` in xlsum_ja

### DIFF
--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -102,7 +102,14 @@ class XLSumJa(Task):
             for s in sentences:
                 tmp = add_sentences + [s]
                 if len(self._tokenize(text="。".join(tmp))) > max_length_per_shot:
-                    add_sentences[-1] += "。"+self.SEP
+                    if len(add_sentences) > 0:
+                        add_sentences[-1] += "。"+self.SEP
+                    else:
+                        # I believe this case does't happen. But, let's make sure to avoid IndexError
+                        # In this case, just truncate the first sentence
+                        token_ids = self._tokenize(s)[:max_length_per_shot]
+                        truncated_s = self.tokenizer.decode(token_ids, skip_special_tokens=True)
+                        add_sentences.append(truncated_s+self.SEP)
                     break
                 add_sentences.append(s)
             c_res += "。".join(add_sentences)

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -52,6 +52,7 @@ class XLSumJa(Task):
     DATASET_NAME = None
     DESCRIPTION = "与えられたニュース記事を要約してください。\n\n"
     LOAD_TOKENIZER = True
+    SEP="\n"
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -89,7 +90,7 @@ class XLSumJa(Task):
         ctxs = [f"{ctx_prompt}{c}"for c in ctx.split(ctx_prompt)]
         description = ""
         if summary_prompt not in ctxs[0]:
-            description = ctxs[0]
+            description = ctxs[0].replace(ctx_prompt, "")
             ctxs = ctxs[1:]
         max_length_per_shot = max_length // len(ctxs)
         res = description
@@ -97,12 +98,17 @@ class XLSumJa(Task):
             text, summary = c.split(summary_prompt)
             sentences = text.split("。")
             c_res = ""
+            add_sentences = []
             for s in sentences:
-                if len(self._tokenize(text=c_res+s)) > max_length_per_shot:
-                    c_res += "\n"
+                tmp = add_sentences + [s]
+                if len(self._tokenize(text="。".join(tmp))) > max_length_per_shot:
+                    add_sentences[-1] += "。"+self.SEP
                     break
-                c_res += s + "。"
+                add_sentences.append(s)
+            c_res += "。".join(add_sentences)
             res += f"{c_res}{summary_prompt}{summary}"
+        # print("#"*100+f"\n{ctx}\n"+"#"*100+f"\n{res}\n"+"#"*100)
+        raise RuntimeError("#"*100+f"\n{res}\n"+"#"*100)
         return res
     
     def _tokenize(self, text, **kwargs):
@@ -120,7 +126,7 @@ class XLSumJa(Task):
             # length + some buffers (10)
             max_num_tokens = len(self._tokenize(doc["summary"])) + 10
         ctx = self.preprocess_ctx(ctx, max_length=self.max_length-max_num_tokens)
-        continuation = rf.greedy_until(ctx, ["\n"], max_num_tokens)
+        continuation = rf.greedy_until(ctx, [self.SEP], max_num_tokens)
         return continuation
 
     def process_results(self, doc, results):
@@ -169,6 +175,9 @@ class XLSumJaWithJAAlpacaPrompt(XLSumJa):
         input_text = f"ニュース記事:{doc['text']}"
         return f"### 指示:\n{self.INSTRUCTION}\n\n### 入力:\n{input_text}\n\n### 応答:\n"
 
+    def preprocess_ctx(self, ctx, max_length):
+        return super().preprocess_ctx(ctx, max_length, ctx_prompt=f"### 指示:\n{self.INSTRUCTION}\n\n### 入力:\n", summary_prompt="### 応答:\n")
+
 
 class XLSumJaWithRinnaInstructionSFT(XLSumJa):
     """
@@ -185,7 +194,9 @@ class XLSumJaWithRinnaInstructionSFT(XLSumJa):
         return f"ユーザー: {input_text}{self.SEP}システム: "
     
     def preprocess_ctx(self, ctx, max_length):
-        return super().preprocess_ctx(ctx, max_length, ctx_prompt=f"{self.SEP}ユーザー: ", summary_prompt=f"{self.SEP}システム: ")
+        ctx = super().preprocess_ctx(ctx, max_length, ctx_prompt=f"ユーザー: ", summary_prompt=f"{self.SEP}システム: ")
+        ctx = ctx.replace("<NL><NL>", "<NL>")
+        return ctx
     
     
 VERSIONS = [

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -107,8 +107,6 @@ class XLSumJa(Task):
                 add_sentences.append(s)
             c_res += "。".join(add_sentences)
             res += f"{c_res}{summary_prompt}{summary}"
-        # print("#"*100+f"\n{ctx}\n"+"#"*100+f"\n{res}\n"+"#"*100)
-        raise RuntimeError("#"*100+f"\n{res}\n"+"#"*100)
         return res
     
     def _tokenize(self, text, **kwargs):


### PR DESCRIPTION
* bug fixes in `xlsum_ja-1.0-0.3`
  ```
  Traceback (most recent call last):
    File "main.py", line 122, in <module>
      main()
    File "main.py", line 91, in main
      results = evaluator.simple_evaluate(
    File "lm-evaluation-harness/lm_eval/utils.py", line 185, in _wrapper
      return fn(*args, **kwargs)
    File "lm-evaluation-harness/lm_eval/evaluator.py", line 87, in simple_evaluate
      results = evaluate(
    File "lm-evaluation-harness/lm_eval/utils.py", line 185, in _wrapper
      return fn(*args, **kwargs)
    File "lm-evaluation-harness/lm_eval/evaluator.py", line 244, in evaluate
      reqs = task.construct_requests(doc, ctx)
    File "lm-evaluation-harness/lm_eval/tasks/ja/xlsum_ja.py", line 122, in construct_requests
      ctx = self.preprocess_ctx(ctx, max_length=self.max_length-max_num_tokens)
    File "lm-evaluation-harness/lm_eval/tasks/ja/xlsum_ja.py", line 97, in preprocess_ctx
      text, summary = c.split(summary_prompt)
  ValueError: not enough values to unpack (expected 2, got 1)
  ```
* also I fixed small changes to convert to better prompts. Now, prompts look like this when `--num_fewshot 1`
  * `xlsum_ja-1.0-0.0`
    ```
    与えられたニュース記事を要約してください。
    
    ニュース記事:民主党が多数を占める下院は昨年12月、トランプ氏を権力乱用と議事妨害で弾劾訴追した。しかし、53対47で共和党が多数の上院では党幹部が当初から、新しい証拠を検討したり新しい証人を尋問することなく、速やかに無
    罪判決を出す方針を示していた。 上院は来週にも、大統領の有罪･無罪について決議する見通し。共和党幹部のミッチ･マコネル上院院内総務は声明で、「上院議員はこれから非公開の場で、下院の弾劾管理人、さらには大統領の法務顧問
    と協議し、裁判を数日中に締めくくる準備のため、次の動きを決める」と述べた。 民主党は、昨年9月に解任されたジョン･ボルトン前大統領補佐官（国家安全保障問題担当）の証言を強く希望していた。ボルトン氏は近く発刊する著書で
    、トランプ氏の発言について書いているとされる。そこには、政敵ジョー･バイデン氏の捜査にウクライナが合意するまで、同国への軍事援助を凍結するつもりだと、トランプ氏が自分に言ったと記述してあるとされる。 米紙ニューヨーク･タイムズが、ボルトン氏の本の内容を報道したのを機に、共和党内でもボルトン氏の証言を求めるべきではないかという意見が出た。しかし最終的に、共和党で証人尋問を支持したのは、スーザン･コリンズ上院議員(メイン州）とミット
    ・ロムニー上院議員（ユタ州）の2人のみで、民主党の動議は否決された。 民主党が頼みの綱にしていたラマー･アレクサンダー上院議員（テネシー州）は採決に先立ち、これまでの審理で民主党はトランプ氏の行動が「不適切」だったこ
    とは証明したものの、それが罷免に相当することにはならないと、証人尋問に反対した。議員は、「問題は（弾劾罷免に相当する問題行動を）大統領が行ったかどうかではなく、大統領がそうしたか判断するのが合衆国上院なのか、それともアメリカ国民なのかだ。月曜にアイオワで始まる大統領選挙で国民がその判断をするよう、憲法は規定しているのだと私は考える」と、証人召喚に反対する理由を説明していた。 同様に、共和党穏健派とされるリサ・マーコウスキー上
    院議員（アラスカ州）も、「下院は拙速で欠陥のある弾劾条項を上院に送ってきた。その手続きの不備を正すために証人や証拠を追加する必要があるか慎重に検討したが、最終的には証人召喚の動議に反対することにした」と発表した。
    大統領の罷免には上院（定数100）の3分の2以上の賛成が必要だが、証人召喚には過半数で足りる。そのため、45議席を持つ民主党は民主系無所属議員2人に加え、共和党から4人の賛成を得られれば、ボルトン氏らの証言を求めることがで
    きた。 下院は、トランプ氏が昨年7月にウクライナ大統領との電話で、軍事援助の凍結解除をちらつかせながら、バイデン親子への捜査を働きかけたほか、これに対する下院の調査を妨害したとして、トランプ氏を昨年12月に弾劾訴追した。 ボルトン氏は昨年9月、大統領補佐官（国家安全保障問題担当）から解任された もしもボルトン氏が上院で、大統領が確かに自分を選挙で有利にするために外国に交換条件として軍事援助の凍結解除を提示したと証言した場合、トラン
    プ氏のよる権力乱用の重要な証拠になると、民主党は期待していた。 トランプ氏の弁護団はこうした事態を受け、大統領が自分の再選のために行うあらゆる行為は国民の利益のためだと言えるので、罷免には相当しないと主張。これには
    共和党からも異議が出ていた。 ホワイトハウスはその一方、国家安全保障上の重要機密が漏洩される懸念を理由に、ボルトン氏の著書の出版を阻止しようとしている。ボルトン氏は、そのような機密は本に含まれていないと反論している
    。 （英語記事 Trump impeachment: Failed witnesses vote paves way for acquittal）
    要約:ドナルド･トランプ米大統領に対する弾劾裁判の審理を勧める米上院（定数100）は31日、新しく証人を呼ぶよう求める野党･民主党提出の動議を、賛成49、反対51で否決した。これにより、来週にもトランプ氏に無罪判決が出ることがほぼ確実となった。民主党は、与党･共和党の穏健派議員4人による支持を期待していたが、その内2人しか証人尋問を支持しなかった。
    
    ニュース記事:マーク・サベッジ BBC音楽担当記者 スウェーデンの4人組グループであるABBAは、新曲が、「バーチャル・リアリティ」ツアーを企画するとした最近の決定の「予期せぬ結果」だと話した。 新曲の発売日は決まっていないが、そのうちの1曲「I Still Have Faith In You」は今年12月にBBCとNBCの特別テレビ番組で披露される予定だ。 ABBAは公式インスタグラムで「私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです」「まるで時間が止まったかのようでした」と述べた。 ABBAがインスタグラムで行った発表の全文は以下の通り――。 「刺激的なABBAのアバター（編注：デジタル技術で製作した本人の映像）ツアー計画を決行するという決定は、予期せぬ結果を生みました。私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです。だから、それを実行しました。それはまるで時間が止まったかのようで、単に短い休暇をとったかのようなものでした。最高
    に楽しい経験でした！ スタジオ入りの結果2つの新曲が生まれ、そのうちの1曲『I Still Have Faith In You』は私たちのデジタルの分身が12月にNBCとBBCの特別テレビ番組で披露します。私たちは年を取ったかもしれませんが、曲は新しく、満足のいくものになりました。 アグネッタ ベニー ビョルン アンニ・フリッド スウェーデン、ストックホルムで、2018年4月27日」 ABBAの広報担当者ゴレル・ハンサー氏はBBCに、スタジオの雰囲気は「魔法」だったと語った。 「
    何の時間も過ぎていないかのようでした」とハンサー氏は語った。「昔のままのようでした。彼らは幸せそうで、レコーディングは気楽で、温かく、実際とても感動的でした。目に涙を浮かべたのは私だけではありませんでした」。 ただ
    同氏は、ABBAはこれから始まるABBAアバターツアーでホログラム（デジタル技術を使った3次元映像）でのパフォーマンス以外、生での歌唱はしない予定だという。 「これはスタジオだけです、約束できます」と同氏は述べた。「期待しすぎないでください」。 BBCのラジオ番組「PM」の公式ツイッターは、「『彼らは幸せそうで…レコーディングは実際とても感動的で…目に涙を浮かべたのは私だけではありませんでした』。ABBAのマネージャーであるゴレル・ハンサー氏がBBCのパディ・オコネルに、ABBAが35年ぶりの新曲を録音したスタジオの様子を語っています」と、ラジオ音声の一部とともに投稿した。 ABBAは1982年に新曲の録音をやめて以降、報道によると2000年には報酬10億ドルでコンサートツアーを行う提案を受けたにもかかわらず、再結成の圧力に抵抗してきた。 メンバーのアグネッタ・ファルツコグはBBCによる2013年のインタビューで、グループを過去のものとするのを選んだと語った。 ファルツコグは当時、「それはもう遠い
    昔のことで、私たちは年を取り、別々の人生がある」と説明した。 新曲のニュースは、ABBAファンにとっての当たり年にやってきた。グループの歴史を基にした没入間のある展示会がロンドン南東部のサウスバンクで開催中で、ABBAメン
    バーのビョルン・ウルバースとベニー・アンダーソンが作詞家のティム・ライス卿と共に脚本したミュージカル「チェス」もロンドンのウェスト・エンドで再上演されている。 アマンダ・サイフレッドやリリー・ジェイムズ、シェールが
    出演する、ミュージカル「マンマ・ミーア！」の映画版も、英国で7月20日から公開される。 ABBAのカバーバンド「ビョルン・アゲイン」の結成者ロッド・スティーブンス氏はBBCニュースに対し、新曲について「完全に新しい始まり」だ
    と表現した。 ビョルン、アンニ・フレッド、アグネッタ、ベニーの4人は2016年にミュージカル「マンマ・ミーア！」をスウェーデンの劇団が上演した際、観賞に訪れた 「ABBAが新曲を発売すると聞き、私は他のABBAファン全員と同じよ
    うに、即座に何の曲でどんな音になるのかとわくわくしました。1970年代のような音なのか、それとも最新の音になるのか？」 「素晴らしいことです、本当に、だって私たちはABBAの音楽を死ぬほど愛しているからです。ただ素晴らしい
    曲であることを望んでいます、『ダンシング・クイーン』や『マンマ・ミーア』と同じぐらいに」 スティーブンス氏は「ベニーやビョルンは、いい曲じゃなかったらこんな風に発表しないだろうことを私は知っています」とも付け加えた
    。
    要約:
    ``` 
  * `xlsum_ja-1.0-0.3`
    ```
    以下は、タスクを説明する指示と、文脈のある入力の組み合わせです。要求を適切に満たす応答を書きなさい。
    
    ### 指示:
    与えられたニュース記事を要約してください。
    
    ### 入力:
    ニュース記事:民主党が多数を占める下院は昨年12月、トランプ氏を権力乱用と議事妨害で弾劾訴追した。しかし、53対47で共和党が多数の上院では党幹部が当初から、新しい証拠を検討したり新しい証人を尋問することなく、速やかに無
    罪判決を出す方針を示していた。 上院は来週にも、大統領の有罪･無罪について決議する見通し。共和党幹部のミッチ･マコネル上院院内総務は声明で、「上院議員はこれから非公開の場で、下院の弾劾管理人、さらには大統領の法務顧問
    と協議し、裁判を数日中に締めくくる準備のため、次の動きを決める」と述べた。 民主党は、昨年9月に解任されたジョン･ボルトン前大統領補佐官（国家安全保障問題担当）の証言を強く希望していた。ボルトン氏は近く発刊する著書で
    、トランプ氏の発言について書いているとされる。そこには、政敵ジョー･バイデン氏の捜査にウクライナが合意するまで、同国への軍事援助を凍結するつもりだと、トランプ氏が自分に言ったと記述してあるとされる。 米紙ニューヨーク･タイムズが、ボルトン氏の本の内容を報道したのを機に、共和党内でもボルトン氏の証言を求めるべきではないかという意見が出た。しかし最終的に、共和党で証人尋問を支持したのは、スーザン･コリンズ上院議員(メイン州）とミット
    ・ロムニー上院議員（ユタ州）の2人のみで、民主党の動議は否決された。 民主党が頼みの綱にしていたラマー･アレクサンダー上院議員（テネシー州）は採決に先立ち、これまでの審理で民主党はトランプ氏の行動が「不適切」だったこ
    とは証明したものの、それが罷免に相当することにはならないと、証人尋問に反対した。議員は、「問題は（弾劾罷免に相当する問題行動を）大統領が行ったかどうかではなく、大統領がそうしたか判断するのが合衆国上院なのか、それともアメリカ国民なのかだ。月曜にアイオワで始まる大統領選挙で国民がその判断をするよう、憲法は規定しているのだと私は考える」と、証人召喚に反対する理由を説明していた。 同様に、共和党穏健派とされるリサ・マーコウスキー上
    院議員（アラスカ州）も、「下院は拙速で欠陥のある弾劾条項を上院に送ってきた。その手続きの不備を正すために証人や証拠を追加する必要があるか慎重に検討したが、最終的には証人召喚の動議に反対することにした」と発表した。
    大統領の罷免には上院（定数100）の3分の2以上の賛成が必要だが、証人召喚には過半数で足りる。そのため、45議席を持つ民主党は民主系無所属議員2人に加え、共和党から4人の賛成を得られれば、ボルトン氏らの証言を求めることがで
    きた。 下院は、トランプ氏が昨年7月にウクライナ大統領との電話で、軍事援助の凍結解除をちらつかせながら、バイデン親子への捜査を働きかけたほか、これに対する下院の調査を妨害したとして、トランプ氏を昨年12月に弾劾訴追した。 ボルトン氏は昨年9月、大統領補佐官（国家安全保障問題担当）から解任された もしもボルトン氏が上院で、大統領が確かに自分を選挙で有利にするために外国に交換条件として軍事援助の凍結解除を提示したと証言した場合、トラン
    プ氏のよる権力乱用の重要な証拠になると、民主党は期待していた。 トランプ氏の弁護団はこうした事態を受け、大統領が自分の再選のために行うあらゆる行為は国民の利益のためだと言えるので、罷免には相当しないと主張。これには
    共和党からも異議が出ていた。 ホワイトハウスはその一方、国家安全保障上の重要機密が漏洩される懸念を理由に、ボルトン氏の著書の出版を阻止しようとしている。ボルトン氏は、そのような機密は本に含まれていないと反論している
    。 （英語記事 Trump impeachment: Failed witnesses vote paves way for acquittal）
    
    ### 応答:
    ドナルド･トランプ米大統領に対する弾劾裁判の審理を勧める米上院（定数100）は31日、新しく証人を呼ぶよう求める野党･民主党提出の動議を、賛成49、反対51で否決した。これにより、来週にもトランプ氏に無罪判決が出ることがほぼ
    確実となった。民主党は、与党･共和党の穏健派議員4人による支持を期待していたが、その内2人しか証人尋問を支持しなかった。
    
    ### 指示:
    与えられたニュース記事を要約してください。
    
    ### 入力:
    ニュース記事:マーク・サベッジ BBC音楽担当記者 スウェーデンの4人組グループであるABBAは、新曲が、「バーチャル・リアリティ」ツアーを企画するとした最近の決定の「予期せぬ結果」だと話した。 新曲の発売日は決まっていないが、そのうちの1曲「I Still Have Faith In You」は今年12月にBBCとNBCの特別テレビ番組で披露される予定だ。 ABBAは公式インスタグラムで「私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです」「まるで時間が止まったかのようでした」と述べた。 ABBAがインスタグラムで行った発表の全文は以下の通り――。 「刺激的なABBAのアバター（編注：デジタル技術で製作した本人の映像）ツアー計画を決行するという決定は、予期せぬ結果を生みました。私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです。だから、それを実行しました。それはまるで時間が止まったかのようで、単に短い休暇をとったかのようなものでした。最高
    に楽しい経験でした！ スタジオ入りの結果2つの新曲が生まれ、そのうちの1曲『I Still Have Faith In You』は私たちのデジタルの分身が12月にNBCとBBCの特別テレビ番組で披露します。私たちは年を取ったかもしれませんが、曲は新しく、満足のいくものになりました。 アグネッタ ベニー ビョルン アンニ・フリッド スウェーデン、ストックホルムで、2018年4月27日」 ABBAの広報担当者ゴレル・ハンサー氏はBBCに、スタジオの雰囲気は「魔法」だったと語った。 「
    何の時間も過ぎていないかのようでした」とハンサー氏は語った。「昔のままのようでした。彼らは幸せそうで、レコーディングは気楽で、温かく、実際とても感動的でした。目に涙を浮かべたのは私だけではありませんでした」。 ただ
    同氏は、ABBAはこれから始まるABBAアバターツアーでホログラム（デジタル技術を使った3次元映像）でのパフォーマンス以外、生での歌唱はしない予定だという。 「これはスタジオだけです、約束できます」と同氏は述べた。「期待しすぎないでください」。 BBCのラジオ番組「PM」の公式ツイッターは、「『彼らは幸せそうで…レコーディングは実際とても感動的で…目に涙を浮かべたのは私だけではありませんでした』。ABBAのマネージャーであるゴレル・ハンサー氏がBBCのパディ・オコネルに、ABBAが35年ぶりの新曲を録音したスタジオの様子を語っています」と、ラジオ音声の一部とともに投稿した。 ABBAは1982年に新曲の録音をやめて以降、報道によると2000年には報酬10億ドルでコンサートツアーを行う提案を受けたにもかかわらず、再結成の圧力に抵抗してきた。 メンバーのアグネッタ・ファルツコグはBBCによる2013年のインタビューで、グループを過去のものとするのを選んだと語った。 ファルツコグは当時、「それはもう遠い
    昔のことで、私たちは年を取り、別々の人生がある」と説明した。 新曲のニュースは、ABBAファンにとっての当たり年にやってきた。グループの歴史を基にした没入間のある展示会がロンドン南東部のサウスバンクで開催中で、ABBAメン
    バーのビョルン・ウルバースとベニー・アンダーソンが作詞家のティム・ライス卿と共に脚本したミュージカル「チェス」もロンドンのウェスト・エンドで再上演されている。 アマンダ・サイフレッドやリリー・ジェイムズ、シェールが
    出演する、ミュージカル「マンマ・ミーア！」の映画版も、英国で7月20日から公開される。 ABBAのカバーバンド「ビョルン・アゲイン」の結成者ロッド・スティーブンス氏はBBCニュースに対し、新曲について「完全に新しい始まり」だ
    と表現した。 ビョルン、アンニ・フレッド、アグネッタ、ベニーの4人は2016年にミュージカル「マンマ・ミーア！」をスウェーデンの劇団が上演した際、観賞に訪れた 「ABBAが新曲を発売すると聞き、私は他のABBAファン全員と同じよ
    うに、即座に何の曲でどんな音になるのかとわくわくしました。1970年代のような音なのか、それとも最新の音になるのか？」 「素晴らしいことです、本当に、だって私たちはABBAの音楽を死ぬほど愛しているからです。
    ### 応答:
    ```
  * `xlsum_ja-1.0-0.4`
    ```
    ユーザー: 与えられたニュース記事を要約してください。<NL>システム: 分かりました。<NL>ユーザー: ニュース記事:民主党が多数を占める下院は昨年12月、トランプ氏を権力乱用と議事妨害で弾劾訴追した。しかし、53対47で共和党が
    多数の上院では党幹部が当初から、新しい証拠を検討したり新しい証人を尋問することなく、速やかに無罪判決を出す方針を示していた。 上院は来週にも、大統領の有罪･無罪について決議する見通し。共和党幹部のミッチ･マコネル上院
    院内総務は声明で、「上院議員はこれから非公開の場で、下院の弾劾管理人、さらには大統領の法務顧問と協議し、裁判を数日中に締めくくる準備のため、次の動きを決める」と述べた。 民主党は、昨年9月に解任されたジョン･ボルトン
    前大統領補佐官（国家安全保障問題担当）の証言を強く希望していた。ボルトン氏は近く発刊する著書で、トランプ氏の発言について書いているとされる。そこには、政敵ジョー･バイデン氏の捜査にウクライナが合意するまで、同国への
    軍事援助を凍結するつもりだと、トランプ氏が自分に言ったと記述してあるとされる。 米紙ニューヨーク･タイムズが、ボルトン氏の本の内容を報道したのを機に、共和党内でもボルトン氏の証言を求めるべきではないかという意見が出た。しかし最終的に、共和党で証人尋問を支持したのは、スーザン･コリンズ上院議員(メイン州）とミット・ロムニー上院議員（ユタ州）の2人のみで、民主党の動議は否決された。 民主党が頼みの綱にしていたラマー･アレクサンダー上院
    議員（テネシー州）は採決に先立ち、これまでの審理で民主党はトランプ氏の行動が「不適切」だったことは証明したものの、それが罷免に相当することにはならないと、証人尋問に反対した。議員は、「問題は（弾劾罷免に相当する問題行動を）大統領が行ったかどうかではなく、大統領がそうしたか判断するのが合衆国上院なのか、それともアメリカ国民なのかだ。月曜にアイオワで始まる大統領選挙で国民がその判断をするよう、憲法は規定しているのだと私は考える」と、証人召喚に反対する理由を説明していた。 同様に、共和党穏健派とされるリサ・マーコウスキー上院議員（アラスカ州）も、「下院は拙速で欠陥のある弾劾条項を上院に送ってきた。その手続きの不備を正すために証人や証拠を追加
    する必要があるか慎重に検討したが、最終的には証人召喚の動議に反対することにした」と発表した。 大統領の罷免には上院（定数100）の3分の2以上の賛成が必要だが、証人召喚には過半数で足りる。そのため、45議席を持つ民主党は民主系無所属議員2人に加え、共和党から4人の賛成を得られれば、ボルトン氏らの証言を求めることができた。 下院は、トランプ氏が昨年7月にウクライナ大統領との電話で、軍事援助の凍結解除をちらつかせながら、バイデン親子への捜査を働きかけたほか、これに対する下院の調査を妨害したとして、トランプ氏を昨年12月に弾劾訴追した。<NL>システム: ドナルド･トランプ米大統領に対する弾劾裁判の審理を勧める米上院（定数100）は31日、新しく証人を呼ぶよう求める野党･民主党提出の動議を、賛成49、反対51で否決した。これにより、来週にもトランプ氏に無罪判決が出ることがほぼ確実となった。民主党は、与党･共和党の穏健派議員4人による支持を期待していたが、その内2人しか証人尋問を支持しなかった。<NL>ユーザー: ニュース記事:マーク・サベッジ BBC音楽担当記者 スウェーデンの4人組グループであるABBAは、新曲が、「バーチャル・リアリティ」ツアーを企画するとした最近の決定の「予期せぬ結果」だと話した。 新曲の発売日は決まっていないが、そのうちの1曲「I Still Have Faith In You」は今年12月にBBCとNBCの特別テレビ番組で披露される予定だ。 ABBAは公式インスタグラムで「私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです」「まるで時間が止まったかのようでした」と述べた。 ABBAがインスタグラムで行った発表の全文は以下の通り――。 「刺激的なABBAのアバター（編注：デジタル技術で製作した本人の映像）ツアー計画を決行するという決定は、予期せぬ結果を生みました。私たち4人は、35年あまり経って、再び手を組み、スタジオに入るのも面白いと感じたのです。だから、それを実行しました。それはまるで時間が止まったかのようで、単に短い休暇をとっ
    たかのようなものでした。最高に楽しい経験でした！ スタジオ入りの結果2つの新曲が生まれ、そのうちの1曲『I Still Have Faith In You』は私たちのデジタルの分身が12月にNBCとBBCの特別テレビ番組で披露します。私たちは年を取ったかもしれませんが、曲は新しく、満足のいくものになりました。 アグネッタ ベニー ビョルン アンニ・フリッド スウェーデン、ストックホルムで、2018年4月27日」 ABBAの広報担当者ゴレル・ハンサー氏はBBCに、スタジオの雰囲気は「魔法」だったと語った。 「何の時間も過ぎていないかのようでした」とハンサー氏は語った。「昔のままのようでした。彼らは幸せそうで、レコーディングは気楽で、温かく、実際とても感動的でした。目に涙を浮かべたのは私だけで
    はありませんでした」。 ただ同氏は、ABBAはこれから始まるABBAアバターツアーでホログラム（デジタル技術を使った3次元映像）でのパフォーマンス以外、生での歌唱はしない予定だという。 「これはスタジオだけです、約束できます
    」と同氏は述べた。「期待しすぎないでください」。 BBCのラジオ番組「PM」の公式ツイッターは、「『彼らは幸せそうで…レコーディングは実際とても感動的で…目に涙を浮かべたのは私だけではありませんでした』。ABBAのマネージャーであるゴレル・ハンサー氏がBBCのパディ・オコネルに、ABBAが35年ぶりの新曲を録音したスタジオの様子を語っています」と、ラジオ音声の一部とともに投稿した。 ABBAは1982年に新曲の録音をやめて以降、報道によると2000年には報酬10億ドルでコンサートツアーを行う提案を受けたにもかかわらず、再結成の圧力に抵抗してきた。 メンバーのアグネッタ・ファルツコグはBBCによる2013年のインタビューで、グループを過去のものとするのを選んだと語った。<NL>システム:
    ```

## To reproduce

```
python main.py --model hf-causal --model_args "pretrained=rinna/japanese-gpt-neox-3.6b-instruction-ppo,use_fast=False" --tasks "xlsum_ja-1.0-0.3" --num_fewshot "1" --device "cuda"
```