### PR TITLE
Add 4 new evaluation tasks for 7 JP models

### DIFF
--- a/models/cyberagent/cyberagent-open-calm-3b/harness.sh
+++ b/models/cyberagent/cyberagent-open-calm-3b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=cyberagent/open-calm-3b"
-TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/cyberagent-open-calm-3b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.1-0.2,xlsum_ja,xwinograd_ja,mgsm"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/cyberagent/cyberagent-open-calm-3b/result.json"

--- a/models/cyberagent/cyberagent-open-calm-3b/result.json
+++ b/models/cyberagent/cyberagent-open-calm-3b/result.json
@@ -18,36 +18,48 @@
       "acc_norm": 0.8620509243111266,
       "acc_norm_stderr": 0.004554438976572761
     },
-    "jsquad-1.1-0.2": {
-      "exact_match": 41.647906348491674,
-      "f1": 53.3615935638234
-    },
-    "xlsum_ja": {
-      "rouge2": 2.043355220946065
-    },
     "xwinograd_ja": {
       "acc": 0.6360792492179353,
       "acc_stderr": 0.015544482535576241
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 40.45475011256191,
+      "f1": 52.73709875917724
+    },
+    "jaqket_v2-0.1-0.2": {
+      "exact_match": 46.90721649484536,
+      "f1": 51.615597556319194
+    },
+    "xlsum_ja": {
+      "rouge2": 1.948450071736146
+    },
+    "mgsm": {
+      "acc": 0.016,
+      "acc_stderr": 0.007951661188874344
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
-    "jsquad-1.1-0.2": 1.1,
     "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.1-0.2": 0.1,
     "xlsum_ja": 1.0,
-    "xwinograd_ja": 1.0
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=cyberagent/open-calm-3b",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
       1,
-      0
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-1b/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-1b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-1b,use_fast=False"
-TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-1b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.1-0.2,xlsum_ja,xwinograd_ja,mgsm"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/rinna/rinna-japanese-gpt-1b/result.json"

--- a/models/rinna/rinna-japanese-gpt-1b/result.json
+++ b/models/rinna/rinna-japanese-gpt-1b/result.json
@@ -18,36 +18,48 @@
       "acc_norm": 0.8786187652598535,
       "acc_norm_stderr": 0.0043130554527802374
     },
-    "jsquad-1.1-0.2": {
-      "exact_match": 28.072940117064384,
-      "f1": 45.44848667804334
-    },
-    "xlsum_ja": {
-      "rouge2": 5.4305544197428235
-    },
     "xwinograd_ja": {
       "acc": 0.6454640250260688,
       "acc_stderr": 0.015455512877686553
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 26.181900045024765,
+      "f1": 44.67532835280053
+    },
+    "jaqket_v2-0.1-0.2": {
+      "exact_match": 37.02749140893471,
+      "f1": 57.99059569678122
+    },
+    "xlsum_ja": {
+      "rouge2": 5.335027032779865
+    },
+    "mgsm": {
+      "acc": 0.02,
+      "acc_stderr": 0.008872139507342681
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
-    "jsquad-1.1-0.2": 1.1,
     "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.1-0.2": 0.1,
     "xlsum_ja": 1.0,
-    "xwinograd_ja": 1.0
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=rinna/japanese-gpt-1b,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
       1,
-      0
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-ppo,use_fast=False,device_map=auto,torch_dtype=auto"
-TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,jaqket_v2-0.1-0.4,xlsum_ja-1.0-0.4,xwinograd_ja,mgsm-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-ppo/result.json
@@ -1,29 +1,41 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.4": {
-      "acc": 0.41823056300268097,
-      "acc_stderr": 0.01475239161269813,
-      "acc_norm": 0.42001787310098304,
-      "acc_norm_stderr": 0.014761153248935507
+      "acc": 0.44057193923145666,
+      "acc_stderr": 0.014847715520097282,
+      "acc_norm": 0.4226988382484361,
+      "acc_norm_stderr": 0.014773923335599326
     },
     "jnli-1.1-0.4": {
-      "acc": 0.5414954806902219,
-      "acc_stderr": 0.010101786233828501,
-      "acc_norm": 0.5316351684470009,
-      "acc_norm_stderr": 0.010116445249958434
+      "acc": 0.5419063270336894,
+      "acc_stderr": 0.01010108912658305,
+      "acc_norm": 0.5312243221035333,
+      "acc_norm_stderr": 0.01011696986287914
     },
     "marc_ja-1.1-0.4": {
-      "acc": 0.9013088079235939,
-      "acc_stderr": 0.003966765361568662,
-      "acc_norm": 0.9013088079235939,
-      "acc_norm_stderr": 0.003966765361568662
+      "acc": 0.8960585978374608,
+      "acc_stderr": 0.004030616889059545,
+      "acc_norm": 0.8960585978374608,
+      "acc_norm_stderr": 0.004030616889059545
+    },
+    "xwinograd_ja": {
+      "acc": 0.6913451511991658,
+      "acc_stderr": 0.014924550437257583
     },
     "jsquad-1.1-0.4": {
-      "exact_match": 51.823502926609635,
-      "f1": 64.28166864179428
+      "exact_match": 51.62089149031968,
+      "f1": 63.676339985467465
+    },
+    "jaqket_v2-0.1-0.4": {
+      "exact_match": 50.945017182130584,
+      "f1": 55.79263424624247
     },
     "xlsum_ja-1.0-0.4": {
-      "rouge2": 6.529580204515145
+      "rouge2": 6.633741717885442
+    },
+    "mgsm-1.0-0.4": {
+      "acc": 0.044,
+      "acc_stderr": 0.012997373846574957
     }
   },
   "versions": {
@@ -31,17 +43,23 @@
     "jnli-1.1-0.4": 1.1,
     "marc_ja-1.1-0.4": 1.1,
     "jsquad-1.1-0.4": 1.1,
-    "xlsum_ja-1.0-0.4": 1.0
+    "jaqket_v2-0.1-0.4": 0.1,
+    "xlsum_ja-1.0-0.4": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=rinna/japanese-gpt-neox-3.6b-instruction-ppo,use_fast=False,device_map=auto,torch_dtype=auto",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
-      1
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft-v2,use_fast=False"
-TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,jaqket_v2-0.1-0.4,xlsum_ja-1.0-0.4,xwinograd_ja,mgsm-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft-v2/result.json
@@ -1,53 +1,65 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.4": {
-      "acc": 0.38427167113494193,
-      "acc_stderr": 0.014547650219928198,
-      "acc_norm": 0.37890974084003576,
-      "acc_norm_stderr": 0.014508561075692419
+      "acc": 0.40571939231456655,
+      "acc_stderr": 0.014685466968554148,
+      "acc_norm": 0.40035746201966044,
+      "acc_norm_stderr": 0.014653766897279884
     },
     "jnli-1.1-0.4": {
-      "acc": 0.5336894001643385,
-      "acc_stderr": 0.010113718882021935,
-      "acc_norm": 0.5123253903040262,
-      "acc_norm_stderr": 0.01013367467477837
+      "acc": 0.5345110928512736,
+      "acc_stderr": 0.010112580105763535,
+      "acc_norm": 0.5160230073952342,
+      "acc_norm_stderr": 0.01013154870567732
     },
     "marc_ja-1.1-0.4": {
-      "acc": 0.8947647683056243,
-      "acc_stderr": 0.004081271868486172,
-      "acc_norm": 0.8947647683056243,
-      "acc_norm_stderr": 0.004081271868486172
-    },
-    "jsquad-1.1-0.4": {
-      "exact_match": 45.31742458352094,
-      "f1": 59.7296045907487
-    },
-    "xlsum_ja-1.0-0.4": {
-      "rouge2": 6.198010013992279
+      "acc": 0.8988489710498779,
+      "acc_stderr": 0.0039823327411368055,
+      "acc_norm": 0.8988489710498779,
+      "acc_norm_stderr": 0.0039823327411368055
     },
     "xwinograd_ja": {
       "acc": 0.7122002085505735,
       "acc_stderr": 0.014627278527825317
+    },
+    "jsquad-1.1-0.4": {
+      "exact_match": 44.91220171094102,
+      "f1": 59.37701704807803
+    },
+    "jaqket_v2-0.1-0.4": {
+      "exact_match": 52.83505154639175,
+      "f1": 57.11081730411627
+    },
+    "xlsum_ja-1.0-0.4": {
+      "rouge2": 6.143135835551484
+    },
+    "mgsm-1.0-0.4": {
+      "acc": 0.028,
+      "acc_stderr": 0.010454721651927283
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.4": 1.1,
     "jnli-1.1-0.4": 1.1,
-    "jsquad-1.1-0.4": 1.1,
     "marc_ja-1.1-0.4": 1.1,
+    "jsquad-1.1-0.4": 1.1,
+    "jaqket_v2-0.1-0.4": 0.1,
     "xlsum_ja-1.0-0.4": 1.0,
-    "xwinograd_ja": 1.0
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft-v2,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
       1,
-      0
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft,use_fast=False"
-TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,xlsum_ja-1.0-0.4"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json"
+TASK="jcommonsenseqa-1.1-0.4,jnli-1.1-0.4,marc_ja-1.1-0.4,jsquad-1.1-0.4,jaqket_v2-0.1-0.4,xlsum_ja-1.0-0.4,xwinograd_ja,mgsm-1.0-0.4"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b-instruction-sft/result.json
@@ -1,53 +1,65 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.4": {
-      "acc": 0.36550491510277033,
-      "acc_stderr": 0.014402564872280742,
-      "acc_norm": 0.36371760500446826,
-      "acc_norm_stderr": 0.014387529036766425
+      "acc": 0.3806970509383378,
+      "acc_stderr": 0.014521799243222533,
+      "acc_norm": 0.38159070598748884,
+      "acc_norm_stderr": 0.014528340051823407
     },
     "jnli-1.1-0.4": {
-      "acc": 0.4219391947411668,
-      "acc_stderr": 0.010012456497483196,
-      "acc_norm": 0.3861955628594905,
-      "acc_norm_stderr": 0.009870691921871148
+      "acc": 0.4457682826622843,
+      "acc_stderr": 0.010076952596248856,
+      "acc_norm": 0.40838126540673786,
+      "acc_norm_stderr": 0.009965126356916043
     },
     "marc_ja-1.1-0.4": {
-      "acc": 0.8901662539794836,
-      "acc_stderr": 0.004158761055616328,
-      "acc_norm": 0.8901662539794836,
-      "acc_norm_stderr": 0.004158761055616328
-    },
-    "jsquad-1.1-0.4": {
-      "exact_match": 47.321026564610534,
-      "f1": 61.35722982692858
-    },
-    "xlsum_ja-1.0-0.4": {
-      "rouge2": 4.354465926425856
+      "acc": 0.9061737007324729,
+      "acc_stderr": 0.003851031309635446,
+      "acc_norm": 0.9061737007324729,
+      "acc_norm_stderr": 0.003851031309635446
     },
     "xwinograd_ja": {
       "acc": 0.694473409801877,
       "acc_stderr": 0.014882283146389277
+    },
+    "jsquad-1.1-0.4": {
+      "exact_match": 47.41107609185052,
+      "f1": 61.67308851187465
+    },
+    "jaqket_v2-0.1-0.4": {
+      "exact_match": 53.69415807560137,
+      "f1": 57.76489737829943
+    },
+    "xlsum_ja-1.0-0.4": {
+      "rouge2": 4.735848492592129
+    },
+    "mgsm-1.0-0.4": {
+      "acc": 0.02,
+      "acc_stderr": 0.008872139507342685
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.4": 1.1,
     "jnli-1.1-0.4": 1.1,
-    "jsquad-1.1-0.4": 1.1,
     "marc_ja-1.1-0.4": 1.1,
+    "jsquad-1.1-0.4": 1.1,
+    "jaqket_v2-0.1-0.4": 0.1,
     "xlsum_ja-1.0-0.4": 1.0,
-    "xwinograd_ja": 1.0
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.4": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=rinna/japanese-gpt-neox-3.6b-instruction-sft,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
       1,
-      0
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/stablelm/stablelm-jp-1b-compact-v1/harness.sh
+++ b/models/stablelm/stablelm-jp-1b-compact-v1/harness.sh
@@ -2,8 +2,8 @@
 set -eu
 PROJECT_DIR="/fsx/proj-jp-stablegpt"
 MODEL_ARGS="pretrained=${PROJECT_DIR}/hf_model/1b-compact-v1,tokenizer=${PROJECT_DIR}/tokenizers/compact-hf/,use_fast=False"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-NUM_FEW_SHOTS="2,3,3,3"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.1-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
 python main.py \
     --model hf-causal \
     --model_args $MODEL_ARGS \

--- a/models/stablelm/stablelm-jp-1b-compact-v1/result.json
+++ b/models/stablelm/stablelm-jp-1b-compact-v1/result.json
@@ -1,11 +1,5 @@
 {
   "results": {
-    "marc_ja-1.1-0.2": {
-      "acc": 0.8290896407394489,
-      "acc_stderr": 0.004971574674673313,
-      "acc_norm": 0.8290896407394489,
-      "acc_norm_stderr": 0.004971574674673313
-    },
     "jcommonsenseqa-1.1-0.2": {
       "acc": 0.4709562109025916,
       "acc_stderr": 0.014928465632785326,
@@ -18,25 +12,54 @@
       "acc_norm": 0.4026294165981923,
       "acc_norm_stderr": 0.009942683448992417
     },
+    "marc_ja-1.1-0.2": {
+      "acc": 0.757063132193931,
+      "acc_stderr": 0.005663981049607239,
+      "acc_norm": 0.757063132193931,
+      "acc_norm_stderr": 0.005663981049607239
+    },
+    "xwinograd_ja": {
+      "acc": 0.6339937434827946,
+      "acc_stderr": 0.015563382319228687
+    },
     "jsquad-1.1-0.2": {
-      "exact_match": 32.21521837010356,
-      "f1": 41.65399734161055
+      "exact_match": 29.536244934714095,
+      "f1": 39.00936796569676
+    },
+    "jaqket_v2-0.1-0.2": {
+      "exact_match": 33.24742268041237,
+      "f1": 38.13348879070528
+    },
+    "xlsum_ja": {
+      "rouge2": 4.3964148234614
+    },
+    "mgsm": {
+      "acc": 0.012,
+      "acc_stderr": 0.0069003230236942764
     }
   },
   "versions": {
-    "marc_ja-1.1-0.2": 1.1,
     "jcommonsenseqa-1.1-0.2": 1.1,
+    "jnli-1.1-0.2": 1.1,
+    "marc_ja-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "jnli-1.1-0.2": 1.1
+    "jaqket_v2-0.1-0.2": 0.1,
+    "xlsum_ja": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=/fsx/proj-jp-stablegpt/hf_model/1b-compact-v1,tokenizer=/fsx/proj-jp-stablegpt/tokenizers/compact-hf/,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/stablelm/stablelm-jp-1b-rp_then_jav1-294b/harness.sh
+++ b/models/stablelm/stablelm-jp-1b-rp_then_jav1-294b/harness.sh
@@ -7,8 +7,8 @@ if [ -z ${JP_LLM_PATH+x} ]; then
 fi
 
 MODEL_ARGS="pretrained=$JP_LLM_PATH/hf_model/1b-rp_then_jav1-294b,tokenizer=$JP_LLM_PATH/tokenizers/nai-hf-tokenizer/,use_fast=False"
-TASK="jsquad-1.1-0.2,jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2"
-NUM_FEW_SHOTS="2,3,3,3"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.1-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
 python main.py \
     --model hf-causal \
     --model_args $MODEL_ARGS \

--- a/models/stablelm/stablelm-jp-1b-rp_then_jav1-294b/result.json
+++ b/models/stablelm/stablelm-jp-1b-rp_then_jav1-294b/result.json
@@ -1,10 +1,16 @@
 {
   "results": {
+    "jcommonsenseqa-1.1-0.2": {
+      "acc": 0.2680965147453083,
+      "acc_stderr": 0.013248038756079302,
+      "acc_norm": 0.24039320822162646,
+      "acc_norm_stderr": 0.012780110667692907
+    },
     "jnli-1.1-0.2": {
-      "acc": 0.4009860312243221,
-      "acc_stderr": 0.009936010515698028,
-      "acc_norm": 0.3635990139687757,
-      "acc_norm_stderr": 0.009752269983725555
+      "acc": 0.3278553820870994,
+      "acc_stderr": 0.009517030628219573,
+      "acc_norm": 0.31183237469186526,
+      "acc_norm_stderr": 0.009391536814742456
     },
     "marc_ja-1.1-0.2": {
       "acc": 0.7771189396581792,
@@ -12,31 +18,48 @@
       "acc_norm": 0.7771189396581792,
       "acc_norm_stderr": 0.005496539565709208
     },
-    "jcommonsenseqa-1.1-0.2": {
-      "acc": 0.2680965147453083,
-      "acc_stderr": 0.013248038756079302,
-      "acc_norm": 0.24039320822162646,
-      "acc_norm_stderr": 0.012780110667692907
+    "xwinograd_ja": {
+      "acc": 0.6861313868613139,
+      "acc_stderr": 0.01499321721472398
     },
     "jsquad-1.1-0.2": {
-      "exact_match": 56.39351643403872,
-      "f1": 66.59905762410258
+      "exact_match": 54.02971634398919,
+      "f1": 64.2854711987419
+    },
+    "jaqket_v2-0.1-0.2": {
+      "exact_match": 59.450171821305844,
+      "f1": 65.37892424490362
+    },
+    "xlsum_ja": {
+      "rouge2": 9.662662093427816
+    },
+    "mgsm": {
+      "acc": 0.008,
+      "acc_stderr": 0.0056454836766901585
     }
   },
   "versions": {
+    "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
     "marc_ja-1.1-0.2": 1.1,
     "jsquad-1.1-0.2": 1.1,
-    "jcommonsenseqa-1.1-0.2": 1.1
+    "jaqket_v2-0.1-0.2": 0.1,
+    "xlsum_ja": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=${PROJECT_DIR}/hf_model/1b-rp_then_jav1-294b,tokenizer=${PROJECT_DIR}/tokenizers/nai-hf-tokenizer/,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",


### PR DESCRIPTION
## Overview

This PR adds 4 new evaluation tasks:

- JAQKET_V2 (1-shot)
- xlsum_ja (1-shot)
- wxinograd_ja (0-shot)
- mgsm (5-shot)

for the following 7 JP models:

- rinna-japanese-gpt-neox-3.6b-instruction-ppo
- rinna-japanese-gpt-neox-3.6b-instruction-sft-v2
- rinna-japanese-gpt-neox-3.6b-instruction-sft
- rinna-japanese-gpt-1b
- stablelm-jp-1b-compact-v1
- stablelm-jp-1b-rp_then_jav1-294b
- cyberagent-open-calm-3b

On how these number of few shots were determined, refer to https://discord.com/channels/1062784909191680120/1108193454267318324/1133936241423949870

## Details

While adding these 4 new evaluation tasks for the above 7 models, this PR also does the following:
- Fixes the number of few shots for the existing 4 tasks, as some of the models were incorrectly using 2-shot for JCommonsenseQA and 3-shot for JSQuAD, whereas it should have been 3-shot for JCommonsenseQA and 2-shot for JSQuAD
- Reorders the tasks in all of the models to match the order shown in the [Eval Leaderboard](https://docs.google.com/spreadsheets/d/1l_5KTGbGBVbW4D1LyeldS9WAMYx0ifzRuNgYPFbvIiM/edit?usp=sharing) (to prevent similar mistakes in the number of few shots as above)