### PR TITLE
fix: catch ValueError when converting float in mgsm task

### DIFF
--- a/lm_eval/tasks/ja/mgsm.py
+++ b/lm_eval/tasks/ja/mgsm.py
@@ -99,7 +99,10 @@ class MGSM(GradeSchoolMath8K):
         if matches:
             match_str = matches[-1].strip('.')
             match_str = match_str.replace(",", "")
-            match_float = float(match_str)
+            try:
+                match_float = float(match_str)
+            except ValueError:
+                return INVALID_ANS
             if match_float.is_integer():
                 return int(match_float)
 


### PR DESCRIPTION
This PR fixes the following `ValueError` when converting floats in the `mgsm` task, which I happened to notice when evaluating the `rinna-japanese-gpt-neox-3.6b` model:

```
Traceback (most recent call last):
  File "main.py", line 122, in <module>
    main()
  File "main.py", line 91, in main
    results = evaluator.simple_evaluate(
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/utils.py", line 185, in _wrapper
    return fn(*args, **kwargs)
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/evaluator.py", line 87, in simple_evaluate
    results = evaluate(
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/utils.py", line 185, in _wrapper
    return fn(*args, **kwargs)
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/evaluator.py", line 293, in evaluate
    metrics = task.process_results(doc, requests)
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/tasks/ja/mgsm.py", line 121, in process_results
    extracted_answer = self._extract_answer(completion)
  File "/admin/home-naoki/lm-evaluation-harness/lm_eval/tasks/ja/mgsm.py", line 102, in _extract_answer
    match_float = float(match_str)
ValueError: could not convert string to float: ''
```

Ideally we might want to revisit how we define `ANS_RE` on the following:

- https://github.com/Stability-AI/lm-evaluation-harness/blame/34d003558e2b8e1dec27abf26ed1e2669a0d3e27/lm_eval/tasks/ja/mgsm.py#L23
- https://github.com/Stability-AI/lm-evaluation-harness/blame/34d003558e2b8e1dec27abf26ed1e2669a0d3e27/lm_eval/tasks/ja/mgsm.py#L98

but coming up with a single regular expression to match all kind of numerical values can be a bit complex so hopefully this workaround should be enough for now 🙏 