### PR TITLE
Add 4 new evaluation tasks for 6 JP models

### DIFF
--- a/models/community/cyberagent-open-calm-instruct-3b_1.3.0/harness.sh
+++ b/models/community/cyberagent-open-calm-instruct-3b_1.3.0/harness.sh
@@ -2,11 +2,11 @@
 set -eu
 PROJECT_DIR=""
 MODEL_ARGS="pretrained=${PROJECT_DIR}/instruction_tuning/outputs/open-calm-instruct-3b_1.3.0,tokenizer=cyberagent/open-calm-3b"
-TASK="jsquad-1.1-0.3,jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3"
+TASK="jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-1.0-0.3,xwinograd_ja,mgsm-1.0-0.3"
 python main.py \
     --model hf-causal \
     --model_args $MODEL_ARGS \
     --tasks $TASK \
-    --num_fewshot "2,3,3,3" \
+    --num_fewshot "3,3,3,2,1,1,0,5" \
     --device "cuda" \
-    --output_path "models/open-calm-instruct-3b_1.3.0/result.json"
+    --output_path "models/community/cyberagent-open-calm-instruct-3b_1.3.0/result.json"

--- a/models/community/cyberagent-open-calm-instruct-3b_1.3.0/result.json
+++ b/models/community/cyberagent-open-calm-instruct-3b_1.3.0/result.json
@@ -1,42 +1,65 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.3": {
-      "acc": 0.7015192135835567,
-      "acc_stderr": 0.013685386698397504,
-      "acc_norm": 0.6255585344057194,
-      "acc_norm_stderr": 0.014474549079455518
+      "acc": 0.709562109025916,
+      "acc_stderr": 0.013576910133903362,
+      "acc_norm": 0.646112600536193,
+      "acc_norm_stderr": 0.014300978485999566
     },
     "jnli-1.1-0.3": {
-      "acc": 0.3011503697617091,
-      "acc_stderr": 0.00930063317508552,
-      "acc_norm": 0.25842235004108466,
-      "acc_norm_stderr": 0.008875080429298606
+      "acc": 0.32251437962202134,
+      "acc_stderr": 0.009476621341954925,
+      "acc_norm": 0.2933442892358258,
+      "acc_norm_stderr": 0.009230425066070979
     },
     "marc_ja-1.1-0.3": {
-      "acc": 0.877431906614786,
-      "acc_stderr": 0.004361701432875794,
-      "acc_norm": 0.877431906614786,
-      "acc_norm_stderr": 0.004361701432875794
+      "acc": 0.8955354028601326,
+      "acc_stderr": 0.00403956848782294,
+      "acc_norm": 0.8955354028601326,
+      "acc_norm_stderr": 0.00403956848782294
+    },
+    "xwinograd_ja": {
+      "acc": 0.6392075078206465,
+      "acc_stderr": 0.015515541059528105
     },
     "jsquad-1.1-0.3": {
-      "exact_match": 35.929761368752814,
-      "f1": 45.27144783040928
+      "exact_match": 32.37280504277353,
+      "f1": 41.27834864657371
+    },
+    "jaqket_v2-0.1-0.3": {
+      "exact_match": 32.302405498281786,
+      "f1": 37.16938035237004
+    },
+    "xlsum_ja-1.0-0.3": {
+      "rouge2": 0.3661308935912556
+    },
+    "mgsm-1.0-0.3": {
+      "acc": 0.012,
+      "acc_stderr": 0.006900323023694269
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.3": 1.1,
     "jnli-1.1-0.3": 1.1,
+    "marc_ja-1.1-0.3": 1.1,
     "jsquad-1.1-0.3": 1.1,
-    "marc_ja-1.1-0.3": 1.1
+    "jaqket_v2-0.1-0.3": 0.1,
+    "xlsum_ja-1.0-0.3": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.3": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=${PROJECT_DIR}/instruction_tuning/outputs/open-calm-instruct-3b_1.3.0,tokenizer=cyberagent/open-calm-3b",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-instruct-1b_0.1.0/harness.sh
+++ b/models/rinna/rinna-instruct-1b_0.1.0/harness.sh
@@ -2,11 +2,11 @@
 set -eu
 PROJECT_DIR=""
 MODEL_ARGS="pretrained=${PROJECT_DIR}/instruction_tuning/outputs/rinna-instruct-1b_0.1.0/,tokenizer=rinna/japanese-gpt-1b,use_fast=False"
-TASK="jsquad-1.1-0.3,jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3"
+TASK="jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-1.0-0.3,xwinograd_ja,mgsm-1.0-0.3"
 python main.py \
     --model hf-causal \
     --model_args $MODEL_ARGS \
     --tasks $TASK \
-    --num_fewshot "2,3,3,3" \
+    --num_fewshot "3,3,3,2,1,1,0,5" \
     --device "cuda" \
-    --output_path "models/rinna-instruct-1b_0.1.0/result.json"
+    --output_path "models/rinna/rinna-instruct-1b_0.1.0/result.json"

--- a/models/rinna/rinna-instruct-1b_0.1.0/result.json
+++ b/models/rinna/rinna-instruct-1b_0.1.0/result.json
@@ -1,10 +1,10 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.3": {
-      "acc": 0.6166219839142091,
-      "acc_stderr": 0.014541265470786009,
+      "acc": 0.6175156389633601,
+      "acc_stderr": 0.014534828771100699,
       "acc_norm": 0.5120643431635389,
-      "acc_norm_stderr": 0.014949361502212126
+      "acc_norm_stderr": 0.014949361502212136
     },
     "jnli-1.1-0.3": {
       "acc": 0.2921117502054232,
@@ -13,30 +13,53 @@
       "acc_norm_stderr": 0.00888882393679571
     },
     "marc_ja-1.1-0.3": {
-      "acc": 0.7649451715599576,
-      "acc_stderr": 0.005639755149907462,
-      "acc_norm": 0.7649451715599576,
-      "acc_norm_stderr": 0.005639755149907462
+      "acc": 0.788280432507848,
+      "acc_stderr": 0.005395477692275257,
+      "acc_norm": 0.788280432507848,
+      "acc_norm_stderr": 0.005395477692275257
+    },
+    "xwinograd_ja": {
+      "acc": 0.6496350364963503,
+      "acc_stderr": 0.015413891595766074
     },
     "jsquad-1.1-0.3": {
-      "exact_match": 15.511031067086897,
-      "f1": 23.80367477675152
+      "exact_match": 17.086897793786584,
+      "f1": 26.487150700412975
+    },
+    "jaqket_v2-0.1-0.3": {
+      "exact_match": 20.876288659793815,
+      "f1": 27.990153222111978
+    },
+    "xlsum_ja-1.0-0.3": {
+      "rouge2": 1.3375721893967882
+    },
+    "mgsm-1.0-0.3": {
+      "acc": 0.012,
+      "acc_stderr": 0.006900323023694273
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.3": 1.1,
     "jnli-1.1-0.3": 1.1,
+    "marc_ja-1.1-0.3": 1.1,
     "jsquad-1.1-0.3": 1.1,
-    "marc_ja-1.1-0.3": 1.1
+    "jaqket_v2-0.1-0.3": 0.1,
+    "xlsum_ja-1.0-0.3": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.3": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=${PROJECT_DIR}/instruction_tuning/outputs/rinna-instruct-1b_0.1.0/,tokenizer=rinna/japanese-gpt-1b,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b/harness.sh
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b/harness.sh
@@ -1,3 +1,3 @@
 MODEL_ARGS="pretrained=rinna/japanese-gpt-neox-3.6b,use_fast=False"
-TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,xlsum_ja"
-python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "2,3,3,3,1" --device "cuda" --output_path "models/rinna-japanese-gpt-neox-3.6b/result.json"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.1-0.2,xlsum_ja,xwinograd_ja,mgsm"
+python main.py --model hf-causal --model_args $MODEL_ARGS --tasks $TASK --num_fewshot "3,3,3,2,1,1,0,5" --device "cuda" --output_path "models/rinna/rinna-japanese-gpt-neox-3.6b/result.json"

--- a/models/rinna/rinna-japanese-gpt-neox-3.6b/result.json
+++ b/models/rinna/rinna-japanese-gpt-neox-3.6b/result.json
@@ -18,36 +18,48 @@
       "acc_norm": 0.7481688175793513,
       "acc_norm_stderr": 0.005732757658862212
     },
-    "jsquad-1.1-0.2": {
-      "exact_match": 50.29266096352994,
-      "f1": 61.107638748126
-    },
-    "xlsum_ja": {
-      "rouge2": 5.17647093477623
-    },
     "xwinograd_ja": {
       "acc": 0.708029197080292,
       "acc_stderr": 0.014689686963716971
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 47.90634849167042,
+      "f1": 58.804568288439675
+    },
+    "jaqket_v2-0.1-0.2": {
+      "exact_match": 68.38487972508591,
+      "f1": 72.4344388906244
+    },
+    "xlsum_ja": {
+      "rouge2": 5.157849646982534
+    },
+    "mgsm": {
+      "acc": 0.012,
+      "acc_stderr": 0.006900323023694271
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.2": 1.1,
     "jnli-1.1-0.2": 1.1,
-    "jsquad-1.1-0.2": 1.1,
     "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.1-0.2": 0.1,
     "xlsum_ja": 1.0,
-    "xwinograd_ja": 1.0
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=rinna/japanese-gpt-neox-3.6b,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3,
       1,
-      0
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/stablelm/stablelm-jp-instruct-1b_1.1.0/harness.sh
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.1.0/harness.sh
@@ -2,11 +2,11 @@
 MODEL_DIR=""
 TOKENIZER_DIR=""
 MODEL_ARGS="pretrained=${MODEL_DIR}/stablelm-jp-instruct-1b_1.1.0/,tokenizer=${TOKENIZER_DIR}/nai-hf-tokenizer/,use_fast=False"
-TASK="jsquad-1.1-0.3,jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3"
+TASK="jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-1.0-0.3,xwinograd_ja,mgsm-1.0-0.3"
 python main.py \
     --model hf-causal \
     --model_args $MODEL_ARGS \
     --tasks $TASK \
-    --num_fewshot "2,3,3,3" \
+    --num_fewshot "3,3,3,2,1,1,0,5" \
     --device "cuda" \
-    --output_path "models/stablelm-jp-instruct-1b_1.1.0/result.json"
+    --output_path "models/stablelm/stablelm-jp-instruct-1b_1.1.0/result.json"

--- a/models/stablelm/stablelm-jp-instruct-1b_1.1.0/result.json
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.1.0/result.json
@@ -1,42 +1,65 @@
 {
   "results": {
     "jcommonsenseqa-1.1-0.3": {
-      "acc": 0.5540661304736372,
-      "acc_stderr": 0.014866034257323042,
-      "acc_norm": 0.5022341376228776,
-      "acc_norm_stderr": 0.014953565834041985
+      "acc": 0.5737265415549598,
+      "acc_stderr": 0.014790256821397245,
+      "acc_norm": 0.5236818588025023,
+      "acc_norm_stderr": 0.014936932699346655
     },
     "jnli-1.1-0.3": {
-      "acc": 0.5110928512736237,
-      "acc_stderr": 0.010134260008247523,
-      "acc_norm": 0.49465899753492193,
-      "acc_norm_stderr": 0.01013617665318336
+      "acc": 0.5012325390304027,
+      "acc_stderr": 0.010136724199459397,
+      "acc_norm": 0.4913722267871816,
+      "acc_norm_stderr": 0.010135245756626698
     },
     "marc_ja-1.1-0.3": {
-      "acc": 0.857976653696498,
-      "acc_stderr": 0.0046427800869554255,
-      "acc_norm": 0.857976653696498,
-      "acc_norm_stderr": 0.0046427800869554255
+      "acc": 0.7720613882106732,
+      "acc_stderr": 0.0055404353974184035,
+      "acc_norm": 0.7720613882106732,
+      "acc_norm_stderr": 0.0055404353974184035
+    },
+    "xwinograd_ja": {
+      "acc": 0.5891553701772679,
+      "acc_stderr": 0.01589538213585439
     },
     "jsquad-1.1-0.3": {
-      "exact_match": 24.493471409275102,
-      "f1": 32.6169342809173
+      "exact_match": 22.039621791985592,
+      "f1": 30.449070373003845
+    },
+    "jaqket_v2-0.1-0.3": {
+      "exact_match": 21.477663230240548,
+      "f1": 26.205875071854457
+    },
+    "xlsum_ja-1.0-0.3": {
+      "rouge2": 3.3480300612823797
+    },
+    "mgsm-1.0-0.3": {
+      "acc": 0.012,
+      "acc_stderr": 0.006900323023694283
     }
   },
   "versions": {
     "jcommonsenseqa-1.1-0.3": 1.1,
     "jnli-1.1-0.3": 1.1,
+    "marc_ja-1.1-0.3": 1.1,
     "jsquad-1.1-0.3": 1.1,
-    "marc_ja-1.1-0.3": 1.1
+    "jaqket_v2-0.1-0.3": 0.1,
+    "xlsum_ja-1.0-0.3": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.3": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=/PATH/TO/stablelm-jp-instruct-1b_1.1.0/,tokenizer=/PATH/TO/nai-hf-tokenizer/,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/stablelm/stablelm-jp-instruct-1b_1.5.2/harness.sh
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.5.2/harness.sh
@@ -4,8 +4,8 @@ PROJECT_DIR=""
 PRETRAINED="${PROJECT_DIR}/sft/checkpoints/stablelm-jp-instruct-1b_1.5.2"
 TOKENIZER="${PROJECT_DIR}/tokenizers/nai-hf-tokenizer/,use_fast=False"
 MODEL_ARGS="pretrained=${PRETRAINED},tokenizer=${TOKENIZER}"
-TASK="jsquad-1.1-0.3,jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3"
-NUM_FEWSHOTS="2,3,3,3"
+TASK="jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-1.0-0.3,xwinograd_ja,mgsm-1.0-0.3"
+NUM_FEWSHOTS="3,3,3,2,1,1,0,5"
 OUTPUT_PATH="models/stablelm/stablelm-jp-instruct-1b_1.5.2/result.json"
 time python main.py \
     --model hf-causal \

--- a/models/stablelm/stablelm-jp-instruct-1b_1.5.2/result.json
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.5.2/result.json
@@ -1,9 +1,5 @@
 {
   "results": {
-    "jsquad-1.1-0.3": {
-      "exact_match": 25.123818099954974,
-      "f1": 33.419537721237795
-    },
     "jcommonsenseqa-1.1-0.3": {
       "acc": 0.5924932975871313,
       "acc_stderr": 0.0146956296030097,
@@ -17,26 +13,53 @@
       "acc_norm_stderr": 0.010130127720772233
     },
     "marc_ja-1.1-0.3": {
-      "acc": 0.8063318004952246,
-      "acc_stderr": 0.005255893527346323,
-      "acc_norm": 0.8063318004952246,
-      "acc_norm_stderr": 0.005255893527346323
+      "acc": 0.8153121730031392,
+      "acc_stderr": 0.005124955846891514,
+      "acc_norm": 0.8153121730031392,
+      "acc_norm_stderr": 0.005124955846891514
+    },
+    "xwinograd_ja": {
+      "acc": 0.59436913451512,
+      "acc_stderr": 0.015863932992497887
+    },
+    "jsquad-1.1-0.3": {
+      "exact_match": 25.123818099954974,
+      "f1": 33.419537721237795
+    },
+    "jaqket_v2-0.1-0.3": {
+      "exact_match": 21.219931271477662,
+      "f1": 25.669774574413754
+    },
+    "xlsum_ja-1.0-0.3": {
+      "rouge2": 3.073093004630064
+    },
+    "mgsm-1.0-0.3": {
+      "acc": 0.008,
+      "acc_stderr": 0.005645483676690158
     }
   },
   "versions": {
-    "jsquad-1.1-0.3": 1.1,
     "jcommonsenseqa-1.1-0.3": 1.1,
     "jnli-1.1-0.3": 1.1,
-    "marc_ja-1.1-0.3": 1.1
+    "marc_ja-1.1-0.3": 1.1,
+    "jsquad-1.1-0.3": 1.1,
+    "jaqket_v2-0.1-0.3": 0.1,
+    "xlsum_ja-1.0-0.3": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.3": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=sft/checkpoints/stablelm-jp-instruct-1b_1.5.2,tokenizer=tokenizers/nai-hf-tokenizer/,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",

--- a/models/stablelm/stablelm-jp-instruct-1b_1.6.2/harness.sh
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.6.2/harness.sh
@@ -4,8 +4,8 @@ PROJECT_DIR=""
 PRETRAINED="${PROJECT_DIR}/sft/checkpoints/stablelm-jp-instruct-1b_1.6.2/"
 TOKENIZER="${PROJECT_DIR}/tokenizers/nai-hf-tokenizer/,use_fast=False"
 MODEL_ARGS="pretrained=${PRETRAINED},tokenizer=${TOKENIZER}"
-TASK="jsquad-1.1-0.3,jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3"
-NUM_FEWSHOTS="2,3,3,3"
+TASK="jcommonsenseqa-1.1-0.3,jnli-1.1-0.3,marc_ja-1.1-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-1.0-0.3,xwinograd_ja,mgsm-1.0-0.3"
+NUM_FEWSHOTS="3,3,3,2,1,1,0,5"
 OUTPUT_PATH="models/stablelm/stablelm-jp-instruct-1b_1.6.2/result.json"
 python main.py \
     --model hf-causal \

--- a/models/stablelm/stablelm-jp-instruct-1b_1.6.2/result.json
+++ b/models/stablelm/stablelm-jp-instruct-1b_1.6.2/result.json
@@ -1,9 +1,5 @@
 {
   "results": {
-    "jsquad-1.1-0.3": {
-      "exact_match": 25.14633048176497,
-      "f1": 33.82421669704697
-    },
     "jcommonsenseqa-1.1-0.3": {
       "acc": 0.579982126899017,
       "acc_stderr": 0.014761153248935519,
@@ -17,26 +13,53 @@
       "acc_norm_stderr": 0.010133465863429315
     },
     "marc_ja-1.1-0.3": {
-      "acc": 0.7341704987619384,
-      "acc_stderr": 0.00587571280566276,
-      "acc_norm": 0.7341704987619384,
-      "acc_norm_stderr": 0.00587571280566276
+      "acc": 0.7469480292989187,
+      "acc_stderr": 0.005741945736263816,
+      "acc_norm": 0.7469480292989187,
+      "acc_norm_stderr": 0.005741945736263816
+    },
+    "xwinograd_ja": {
+      "acc": 0.5933263816475496,
+      "acc_stderr": 0.015870370841796246
+    },
+    "jsquad-1.1-0.3": {
+      "exact_match": 25.14633048176497,
+      "f1": 33.82421669704697
+    },
+    "jaqket_v2-0.1-0.3": {
+      "exact_match": 21.993127147766323,
+      "f1": 26.43369755483157
+    },
+    "xlsum_ja-1.0-0.3": {
+      "rouge2": 2.905130175874733
+    },
+    "mgsm-1.0-0.3": {
+      "acc": 0.004,
+      "acc_stderr": 0.004000000000000003
     }
   },
   "versions": {
-    "jsquad-1.1-0.3": 1.1,
     "jcommonsenseqa-1.1-0.3": 1.1,
     "jnli-1.1-0.3": 1.1,
-    "marc_ja-1.1-0.3": 1.1
+    "marc_ja-1.1-0.3": 1.1,
+    "jsquad-1.1-0.3": 1.1,
+    "jaqket_v2-0.1-0.3": 0.1,
+    "xlsum_ja-1.0-0.3": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm-1.0-0.3": 1.0
   },
   "config": {
     "model": "hf-causal",
     "model_args": "pretrained=sft/checkpoints/stablelm-jp-instruct-1b_1.6.2/,tokenizer=tokenizers/nai-hf-tokenizer/,use_fast=False",
     "num_fewshot": [
+      3,
+      3,
+      3,
       2,
-      3,
-      3,
-      3
+      1,
+      1,
+      0,
+      5
     ],
     "batch_size": null,
     "device": "cuda",


### PR DESCRIPTION
## Overview

This PR is a follow-up to #67 and adds 4 new evaluation tasks:

- JAQKET_V2 (1-shot)
- xlsum_ja (1-shot)
- wxinograd_ja (0-shot)
- mgsm (5-shot)

for the following 6 JP models:

- cyberagent-open-calm-instruct-3b_1.3.0
- rinna-instruct-1b_0.1.0
- rinna-japanese-gpt-neox-3.6b
- stablelm-jp-instruct-1b_1.1.0
- stablelm-jp-instruct-1b_1.5.2
- stablelm-jp-instruct-1b_1.6.2

## Details

Similar to #67, while adding these 4 new evaluation tasks for the above 6 models, this PR also re-orders the tasks in all of the models to match the order shown in the [Eval Leaderboard](https://docs.google.com/spreadsheets/d/1l_5KTGbGBVbW4D1LyeldS9WAMYx0ifzRuNgYPFbvIiM/edit?usp=sharing) for consistency.