### PR TITLE
Add configs for testing harness

### DIFF
--- a/generate_harness.py
+++ b/generate_harness.py
@@ -1,0 +1,99 @@
+import sys
+import configparser
+from pathlib import Path
+import argparse
+
+"""
+A script to generate a harness shell script for running eval in a cluster.
+
+Given a model directory, this script looks for a `harness.conf` file. The file describes the path to the pretrained model (or the HuggingFace model name), the model arguments, the tasks to run, and other details.
+
+Given these details the script outputs a command line which will run eval.
+
+In detail, a config has two kinds of sections: the `[model]` section contains general model options, while task-specific sections have names like `[tasks.MY_TASK-0.1]`.
+
+The model section contains the following values:
+
+- model: almost always hf-causal
+- path: the first arg to AutoModel.load_model
+- tokenizer: path to the tokenizer
+- args: any other model arguments
+
+You can use interpolation in the config file, so it's commmon to include a `project_dir` value and use it like this:
+
+    tokenizer = ${project_dir}/tokenizers/hogehoge
+
+Task sections just contain the `fewshot` parameter for now.
+
+Configs support inheritance. The file at `models/harness.conf` specifies global defaults, while files for each model group can define options not specific for a model. These files are usually the most detailed, since task and prompt selection are usually consistent for a model group.
+"""
+
+def generate_harness(model_dir):
+    path = Path(model_dir).absolute()
+
+    # grandparent is global config, parent is org config.
+    # it's ok if they don't exist.
+    hc = "harness.conf"
+    config_paths = [path.parent.parent / hc, path.parent / hc, path / hc]
+    # used to make PROJECT_DIR work just like shell
+    interp = configparser.ExtendedInterpolation()
+    conf = configparser.ConfigParser(interpolation=interp)
+    conf.read(config_paths)
+
+    # Make the model args. We don't have to interpolate the path here, it can
+    # be handled in the file directly thanks to interpolation.
+    model_path = Path(conf["model"]["path"])
+    tokenizer = conf["model"]["tokenizer"]
+    # args are technically not required
+    args = conf["model"].get("args")
+    model_args = f"pretrained={model_path},tokenizer={tokenizer}"
+    if args:
+        model_args += "," + args
+
+    # Make the task list. Basically just attaching prompt versions, but some tasks
+    # have no prompt versions because they don't use prompts.
+    tasks = []
+    fewshot = []
+    for key, val in conf.items():
+        if not key.startswith("tasks."):
+            continue
+
+        name = key.split(".", 1)[1]
+        prompt = val["prompt"]
+        # By default configparser doesn't handle empty strings
+        # properly, so check for obvious attempts and fix them.
+        if prompt in ("''", '""'):
+            prompt = ""
+        if prompt:
+            name = f"{name}-{prompt}"
+        tasks.append(name)
+        fewshot.append(val["fewshot"])
+
+    tasks = ",".join(tasks)
+    fewshot = ",".join(fewshot)
+
+    output_path = model_path / "result.json"
+    model_type = conf["model"]["model"]
+    script = (
+      "python main.py "
+      f"--device cuda "
+      f"--model {model_type} "
+      f"--model_args {model_args} "
+      f"--tasks {tasks} "
+      f"--num_fewshot {fewshot} "
+      f"--output_path {output_path} "
+      )
+    return script.strip()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+            prog="generate_harness.py",
+            description="Generate an eval command based on configs.",
+            )
+
+    parser.add_argument("model_path")
+
+    args = parser.parse_args()
+    cmd = generate_harness(args.model_path)
+    print(cmd)
+

--- a/models/harness.conf
+++ b/models/harness.conf
@@ -1,0 +1,3 @@
+[model]
+# the --model option to the training script
+model = hf-causal

--- a/models/harness.conf
+++ b/models/harness.conf
@@ -1,3 +1,30 @@
 [model]
 # the --model option to the training script
 model = hf-causal
+
+[tasks.jcommonsenseqa-1.1]
+fewshot = 3
+
+[tasks.jnli]
+fewshot = 3
+
+[tasks.marc_ja]
+fewshot = 3
+
+[tasks.jsquad-1.1]
+fewshot = 2
+
+[tasks.jaqket_v2-0.1]
+fewshot = 1
+
+[tasks.xlsum_ja]
+fewshot = 1
+
+[tasks.xwinograd_ja]
+fewshot = 0
+# This specifically has no prompt
+prompt = ""
+
+[tasks.mgsm]
+fewshot = 5
+

--- a/models/rinna/harness.conf
+++ b/models/rinna/harness.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+# Recent Rinna models use the 0.4 prompt, though note that older ones used
+# other prompts.
+prompt = 0.4

--- a/models/stablelm/harness.conf
+++ b/models/stablelm/harness.conf
@@ -1,6 +1,3 @@
-# To customize this, copy and paste it to the model directory and
-# delete the parts you aren't changing, then customize the rest.
-
 [DEFAULT]
 prompt = 0.3
 
@@ -9,32 +6,4 @@ prompt = 0.3
 project_dir = .
 tokenizer = ${project_dir}/tokenizers/nai-hf-tokenizer/
 args = use_fast=False
-
-[tasks.jcommonsenseqa-1.1]
-fewshot = 3
-
-[tasks.jnli]
-fewshot = 3
-
-[tasks.marc_ja]
-fewshot = 3
-
-[tasks.jsquad-1.1]
-fewshot = 2
-
-[tasks.jaqket_v2-0.1]
-fewshot = 1
-
-[tasks.xlsum_ja]
-fewshot = 1
-# This specifically has no prompt
-prompt =  ""
-
-[tasks.xwinograd_ja]
-fewshot = 0
-prompt = ""
-
-[tasks.mgsm]
-fewshot = 5
-prompt =  ""
 

--- a/models/stablelm/harness.conf
+++ b/models/stablelm/harness.conf
@@ -1,0 +1,40 @@
+# To customize this, copy and paste it to the model directory and
+# delete the parts you aren't changing, then customize the rest.
+
+[DEFAULT]
+prompt = 0.3
+
+[model]
+# XXX change this to your project dir
+project_dir = .
+tokenizer = ${project_dir}/tokenizers/nai-hf-tokenizer/
+args = use_fast=False
+
+[tasks.jcommonsenseqa-1.1]
+fewshot = 3
+
+[tasks.jnli]
+fewshot = 3
+
+[tasks.marc_ja]
+fewshot = 3
+
+[tasks.jsquad-1.1]
+fewshot = 2
+
+[tasks.jaqket_v2-0.1]
+fewshot = 1
+
+[tasks.xlsum_ja]
+fewshot = 1
+# This specifically has no prompt
+prompt =  ""
+
+[tasks.xwinograd_ja]
+fewshot = 0
+prompt = ""
+
+[tasks.mgsm]
+fewshot = 5
+prompt =  ""
+

--- a/models/stablelm/stablelm-jp-3b-ja50_rp50-700b/harness.conf
+++ b/models/stablelm/stablelm-jp-3b-ja50_rp50-700b/harness.conf
@@ -1,0 +1,2 @@
+[model]
+path = ${PROJECT_DIR}/hf_model/3b-ja50_rp50-700b

--- a/scripts/generate_harness.py
+++ b/scripts/generate_harness.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import configparser
 from pathlib import Path
@@ -47,13 +48,19 @@ def generate_harness(model_dir):
     conf = configparser.ConfigParser(interpolation=interp)
     conf.read(config_paths)
 
-    # Make the model args. We don't have to interpolate the path here, it can
-    # be handled in the file directly thanks to interpolation.
-    model_path = Path(conf["model"]["path"])
-    tokenizer = conf["model"]["tokenizer"]
+    # Build the model args. We don't have to interpolate the path here, it can
+    # be handled in the file directly thanks to interpolation. Also, fall back
+    # to the last two parts of the directory path as the HF name.
+    fallback_path = os.path.join(*path.parts[-2:])
+
+    model_path = conf["model"].get("path", fallback_path)
+    # tokenizer is technically not required, but almost always present
+    tokenizer = conf["model"].get("tokenizer")
     # args are technically not required
     args = conf["model"].get("args")
-    model_args = f"pretrained={model_path},tokenizer={tokenizer}"
+    model_args = f"pretrained={model_path}"
+    if tokenizer:
+        model_arts += "," + f"tokenizer={tokenizer}"
     if args:
         model_args += "," + args
 

--- a/scripts/generate_harness.py
+++ b/scripts/generate_harness.py
@@ -8,6 +8,10 @@ A script to generate a harness shell script for running eval in a cluster.
 
 Given a model directory, this script looks for a `harness.conf` file. The file describes the path to the pretrained model (or the HuggingFace model name), the model arguments, the tasks to run, and other details.
 
+Example usage:
+
+    python scripts/generate_harness.py models/stablelm/stablelm-jp-3b-ja50_rp50-700b/
+
 Given these details the script outputs a command line which will run eval.
 
 In detail, a config has two kinds of sections: the `[model]` section contains general model options, while task-specific sections have names like `[tasks.MY_TASK-0.1]`.
@@ -30,6 +34,9 @@ Configs support inheritance. The file at `models/harness.conf` specifies global 
 
 def generate_harness(model_dir):
     path = Path(model_dir).absolute()
+    if path.is_file():
+        # if we specified a file for some reason, just take the dir
+        path = path.parent
 
     # grandparent is global config, parent is org config.
     # it's ok if they don't exist.
@@ -72,7 +79,7 @@ def generate_harness(model_dir):
     tasks = ",".join(tasks)
     fewshot = ",".join(fewshot)
 
-    output_path = model_path / "result.json"
+    output_path = path / "result.json"
     model_type = conf["model"]["model"]
     script = (
       "python main.py "

--- a/scripts/generate_harness.py
+++ b/scripts/generate_harness.py
@@ -60,7 +60,7 @@ def generate_harness(model_dir):
     args = conf["model"].get("args")
     model_args = f"pretrained={model_path}"
     if tokenizer:
-        model_arts += "," + f"tokenizer={tokenizer}"
+        model_args += "," + f"tokenizer={tokenizer}"
     if args:
         model_args += "," + args
 


### PR DESCRIPTION
This PR adds `scripts/generate_harness.py`. This script can be used to generate a harness command, like that in `harness.sh` scripts, based on the contents of config files. This is an improvement over the current system of copying `harness.sh` scripts for a few reasons, mainly focused on automating changes and ensuring consistency in evaluation.

`harness.sh` scripts are hard to read because of the long options, and it's necessary to keep things like order of task names and few-shot options aligned. In the config, tasks are instead individual config entries, and prompt and few-shot values can be set per-task. Additionally, the result output path can be automatically generated, so there's no risk of forgetting to change it. 

Task-specific config looks a bit like this:

```
[tasks.xlsum_ja]
fewshot = 1
# this will inherit the default prompt version

[tasks.xwinograd_ja]
fewshot = 0
# This specifically has no prompt
prompt = ""
```

This also allows for a hierarchy of configs. For example, it's possible to set a global config at `models/harness.conf` that serves as the base for configs per organization (like `models/stablelm`) or per model. Models in higher dirs will be used as a fallback for values, so you can add an eval task to the global config and re-run all evals to get updated values. 

`generate_harness.py` just generates the command line to actually run the eval, so it doesn't require any changes to existing harness scripts or the eval system. This means it can also be used to generate `harness.sh` scripts like we currently use.

Example usage:

    python scripts/generate_harness.py models/stablelm/stablelm-jp-3b-ja50_rp50-700b/
    # output:
    python main.py --device cuda --model hf-causal --model_args pretrained=./hf_model/3b-ja50_rp50-700b,tokenizer=./tokenizers/nai-hf-tokenizer/,use_fast=False --tasks jcommonsenseqa-1.1-0.3,jnli-0.3,marc_ja-0.3,jsquad-1.1-0.3,jaqket_v2-0.1-0.3,xlsum_ja-0.3,xwinograd_ja,mgsm-0.3 --num_fewshot 3,3,3,2,1,1,0,5 --output_path /mnt/pool/work/stability/lm-evaluation-harness/models/stablelm/stablelm-jp-3b-ja50_rp50-700b/result.json
    # note this uses a placeholder PROJECT_DIR of "."

Further documentation is included at the head of `generate_harness.py`. This PR also includes some base configs to get started. 