### PR TITLE
make dir only if directory is specified in 'output_path'

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,9 @@ def main():
     print(dumped)
 
     if args.output_path:
-        os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
+        dir = os.path.dirname(args.output_path)
+        if dir:
+            os.makedirs(dir, exist_ok=True)
         with open(args.output_path, "w") as f:
             f.write(dumped)
 


### PR DESCRIPTION
make dir only if directory is specified in 'output_path'

On Windows, specifying only file name raises `FileNotFoundError`
```sh
Traceback (most recent call last):
  File "C:\lm-evaluation-harness\main.py", line 122, in <module>
    main()
  File "C:\lm-evaluation-harness\main.py", line 110, in main
    os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
  File "C:\Python310\lib\os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [WinError 3] 指定されたパスが見つかりません。: ''
```