### PR TITLE
Verbose output for more tasks

### DIFF
--- a/lm_eval/tasks/ja/jaqket_v2.py
+++ b/lm_eval/tasks/ja/jaqket_v2.py
@@ -279,7 +279,7 @@ class JAQKETV2(Task):
             "id": doc["qid"],
             "answers": doc["answers"],
         }
-        return {
+        out = {
             "exact_match": (
                 predictions,
                 references,
@@ -289,6 +289,16 @@ class JAQKETV2(Task):
                 references,
             ),  # The F-score of predicted tokens versus the gold answer
         }
+
+        # add details. Because the metric computation isn't simple (probably?)
+        # always include it.
+        out["details"] = {
+            "question": doc["question"],
+            "response": continuation,
+            "gold": doc["answers"]
+        }
+
+        return out
 
 
     def aggregation(self):

--- a/lm_eval/tasks/ja/jsquad.py
+++ b/lm_eval/tasks/ja/jsquad.py
@@ -142,7 +142,7 @@ class JSQuAD(Task):
             "id": doc["id"],
             "answers": doc["answers"],
         }
-        return {
+        out = {
             "exact_match": (
                 predictions,
                 references,
@@ -152,6 +152,15 @@ class JSQuAD(Task):
                 references,
             ),  # The F-score of predicted tokens versus the gold answer
         }
+
+        # add verbose output
+        out["details"] = {
+            "question": doc["question"],
+            "response": continuation,
+            "gold": doc["answers"]
+        }
+
+        return out
 
 
     def aggregation(self):

--- a/lm_eval/tasks/ja/xlsum_ja.py
+++ b/lm_eval/tasks/ja/xlsum_ja.py
@@ -137,12 +137,21 @@ class XLSumJa(Task):
     def process_results(self, doc, results):
         continuation = results[0]
         ground_truth = doc["summary"]
-        return {
+        out = {
             "rouge2": (
                 continuation,
                 ground_truth,
             )
         }
+        # add verbose output
+        out["details"] = {
+            # this isn't really a question, but keeping it this way for
+            # consistency
+            "question": doc["text"],
+            "response": continuation,
+            "gold": doc["summary"]
+        }
+        return out
     
     def aggregation(self):
         return {


### PR DESCRIPTION
This adds the option for verbose output, which saves generated responses, for all standard Japanese tasks where it's applicable. marc-ja, jsnli, and xwinograd don't do generation, so they remain uncovered. 