### PR TITLE
Add evaluation harness for 4 new base models

### DIFF
--- a/models/elyza/ELYZA-japanese-Llama-2-7b-fast/harness.sh
+++ b/models/elyza/ELYZA-japanese-Llama-2-7b-fast/harness.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+MODEL_ARGS="pretrained=elyza/ELYZA-japanese-Llama-2-7b-fast,torch_dtype=auto"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.2-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
+python main.py \
+    --model hf-causal \
+    --model_args $MODEL_ARGS \
+    --tasks $TASK \
+    --num_fewshot $NUM_FEW_SHOTS \
+    --device "cuda" \
+    --output_path "models/elyza/ELYZA-japanese-Llama-2-7b-fast/result.json"

--- a/models/elyza/ELYZA-japanese-Llama-2-7b-fast/result.json
+++ b/models/elyza/ELYZA-japanese-Llama-2-7b-fast/result.json
@@ -1,0 +1,71 @@
+{
+  "results": {
+    "jcommonsenseqa-1.1-0.2": {
+      "acc": 0.5594280607685433,
+      "acc_stderr": 0.01484771552009728,
+      "acc_norm": 0.2966934763181412,
+      "acc_norm_stderr": 0.013661721245717974
+    },
+    "jnli-1.1-0.2": {
+      "acc": 0.21364009860312244,
+      "acc_stderr": 0.008309617058842162,
+      "acc_norm": 0.30238290879211177,
+      "acc_norm_stderr": 0.00931142440446158
+    },
+    "marc_ja-1.1-0.2": {
+      "acc": 0.8760027903732124,
+      "acc_stderr": 0.00435279014819554,
+      "acc_norm": 0.8760027903732124,
+      "acc_norm_stderr": 0.00435279014819554
+    },
+    "xwinograd_ja": {
+      "acc": 0.6131386861313869,
+      "acc_stderr": 0.015735272058140428
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 73.9756866276452,
+      "f1": 85.55200118375015
+    },
+    "jaqket_v2-0.2-0.2": {
+      "exact_match": 64.86254295532646,
+      "f1": 72.54275077728684
+    },
+    "xlsum_ja": {
+      "rouge2": 13.215579230660504
+    },
+    "mgsm": {
+      "acc": 0.076,
+      "acc_stderr": 0.01679357306785966
+    }
+  },
+  "versions": {
+    "jcommonsenseqa-1.1-0.2": 1.1,
+    "jnli-1.1-0.2": 1.1,
+    "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.2-0.2": 0.2,
+    "xlsum_ja": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=elyza/ELYZA-japanese-Llama-2-7b-fast,torch_dtype=auto",
+    "num_fewshot": [
+      3,
+      3,
+      3,
+      2,
+      1,
+      1,
+      0,
+      5
+    ],
+    "batch_size": null,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/models/elyza/ELYZA-japanese-Llama-2-7b/harness.sh
+++ b/models/elyza/ELYZA-japanese-Llama-2-7b/harness.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+MODEL_ARGS="pretrained=elyza/ELYZA-japanese-Llama-2-7b,torch_dtype=auto"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.2-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
+python main.py \
+    --model hf-causal \
+    --model_args $MODEL_ARGS \
+    --tasks $TASK \
+    --num_fewshot $NUM_FEW_SHOTS \
+    --device "cuda" \
+    --output_path "models/elyza/ELYZA-japanese-Llama-2-7b/result.json"

--- a/models/elyza/ELYZA-japanese-Llama-2-7b/result.json
+++ b/models/elyza/ELYZA-japanese-Llama-2-7b/result.json
@@ -1,0 +1,71 @@
+{
+  "results": {
+    "jcommonsenseqa-1.1-0.2": {
+      "acc": 0.5710455764075067,
+      "acc_stderr": 0.014801988397858769,
+      "acc_norm": 0.2966934763181412,
+      "acc_norm_stderr": 0.013661721245717974
+    },
+    "jnli-1.1-0.2": {
+      "acc": 0.18364831552999178,
+      "acc_stderr": 0.00784984473506118,
+      "acc_norm": 0.3073130649137223,
+      "acc_norm_stderr": 0.009353797329146566
+    },
+    "marc_ja-1.1-0.2": {
+      "acc": 0.7190442971747472,
+      "acc_stderr": 0.005936162459629614,
+      "acc_norm": 0.7190442971747472,
+      "acc_norm_stderr": 0.005936162459629614
+    },
+    "xwinograd_ja": {
+      "acc": 0.7132429614181439,
+      "acc_stderr": 0.014611440573117
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 74.31337235479513,
+      "f1": 86.3847509427498
+    },
+    "jaqket_v2-0.2-0.2": {
+      "exact_match": 57.64604810996563,
+      "f1": 68.11284172108913
+    },
+    "xlsum_ja": {
+      "rouge2": 16.349774613861662
+    },
+    "mgsm": {
+      "acc": 0.052,
+      "acc_stderr": 0.01407039102564164
+    }
+  },
+  "versions": {
+    "jcommonsenseqa-1.1-0.2": 1.1,
+    "jnli-1.1-0.2": 1.1,
+    "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.2-0.2": 0.2,
+    "xlsum_ja": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=elyza/ELYZA-japanese-Llama-2-7b,torch_dtype=auto",
+    "num_fewshot": [
+      3,
+      3,
+      3,
+      2,
+      1,
+      1,
+      0,
+      5
+    ],
+    "batch_size": null,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/models/matsuo-lab/weblab-10b/harness.sh
+++ b/models/matsuo-lab/weblab-10b/harness.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+MODEL_ARGS="pretrained=matsuo-lab/weblab-10b,torch_dtype=auto"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.2-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
+python main.py \
+    --model hf-causal \
+    --model_args $MODEL_ARGS \
+    --tasks $TASK \
+    --num_fewshot $NUM_FEW_SHOTS \
+    --device "cuda" \
+    --output_path "models/matsuo-lab/weblab-10b/result.json"

--- a/models/matsuo-lab/weblab-10b/result.json
+++ b/models/matsuo-lab/weblab-10b/result.json
@@ -1,0 +1,71 @@
+{
+  "results": {
+    "jcommonsenseqa-1.1-0.2": {
+      "acc": 0.2359249329758713,
+      "acc_stderr": 0.012697962275643588,
+      "acc_norm": 0.23145665773011617,
+      "acc_norm_stderr": 0.012613863278159715
+    },
+    "jnli-1.1-0.2": {
+      "acc": 0.4026294165981923,
+      "acc_stderr": 0.009942683448992417,
+      "acc_norm": 0.3586688578471652,
+      "acc_norm_stderr": 0.009723372975530546
+    },
+    "marc_ja-1.1-0.2": {
+      "acc": 0.8081618416463202,
+      "acc_stderr": 0.005200267663299235,
+      "acc_norm": 0.8081618416463202,
+      "acc_norm_stderr": 0.005200267663299235
+    },
+    "xwinograd_ja": {
+      "acc": 0.7194994786235662,
+      "acc_stderr": 0.014514407890552965
+    },
+    "jsquad-1.1-0.2": {
+      "exact_match": 77.03737055380459,
+      "f1": 83.43026159995917
+    },
+    "jaqket_v2-0.2-0.2": {
+      "exact_match": 70.36082474226804,
+      "f1": 74.38805705558278
+    },
+    "xlsum_ja": {
+      "rouge2": 20.432194816827852
+    },
+    "mgsm": {
+      "acc": 0.02,
+      "acc_stderr": 0.008872139507342681
+    }
+  },
+  "versions": {
+    "jcommonsenseqa-1.1-0.2": 1.1,
+    "jnli-1.1-0.2": 1.1,
+    "marc_ja-1.1-0.2": 1.1,
+    "jsquad-1.1-0.2": 1.1,
+    "jaqket_v2-0.2-0.2": 0.2,
+    "xlsum_ja": 1.0,
+    "xwinograd_ja": 1.0,
+    "mgsm": 1.0
+  },
+  "config": {
+    "model": "hf-causal",
+    "model_args": "pretrained=matsuo-lab/weblab-10b,torch_dtype=auto",
+    "num_fewshot": [
+      3,
+      3,
+      3,
+      2,
+      1,
+      1,
+      0,
+      5
+    ],
+    "batch_size": null,
+    "device": "cuda",
+    "no_cache": false,
+    "limit": null,
+    "bootstrap_iters": 100000,
+    "description_dict": {}
+  }
+}

--- a/models/pfnet/plamo-13b/harness.sh
+++ b/models/pfnet/plamo-13b/harness.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+MODEL_ARGS="pretrained=pfnet/plamo-13b,use_fast=False,trust_remote_code=True,device_map=auto"
+TASK="jcommonsenseqa-1.1-0.2,jnli-1.1-0.2,marc_ja-1.1-0.2,jsquad-1.1-0.2,jaqket_v2-0.2-0.2,xlsum_ja,xwinograd_ja,mgsm"
+NUM_FEW_SHOTS="3,3,3,2,1,1,0,5"
+python main.py \
+    --model hf-causal \
+    --model_args $MODEL_ARGS \
+    --tasks $TASK \
+    --num_fewshot $NUM_FEW_SHOTS \
+    --device "cuda" \
+    --output_path "models/pfnet/plamo-13b/result.json"


### PR DESCRIPTION
This PR adds evaluation harnesses and results for the following 4 base models:

- pfnet/plamo-13b
- elyza/ELYZA-japanese-Llama-2-7b
- elyza/ELYZA-japanese-Llama-2-7b-fast
- matsuo-lab/weblab-10b