### PR TITLE
Add Balanced Accuracy

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -711,6 +711,13 @@ class MultipleChoiceTask(Task):
         }
 
 class BalancedMultipleChoiceTask(MultipleChoiceTask):
+    """A task where the choices are the same every time, and accuracy should be
+    calculated separately for each class.
+
+    Originally created for marc-ja, which is severely imbalanced, though also
+    useful with less weird datasets. Not suitable for datasets where the choices
+    change for every question.
+    """
     def process_results(self, doc, results):
         gold = doc["gold"]
 

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn.functional as F
 
 from lm_eval.metrics import mean, weighted_perplexity, weighted_mean, bits_per_byte
+from lm_eval.metrics import balanced_mean
 from lm_eval import utils
 from abc import abstractmethod
 
@@ -708,6 +709,35 @@ class MultipleChoiceTask(Task):
             "acc": mean,
             "acc_norm": mean,
         }
+
+class BalancedMultipleChoiceTask(MultipleChoiceTask):
+    def process_results(self, doc, results):
+        gold = doc["gold"]
+
+        acc = 1.0 if np.argmax(results) == gold else 0.0
+        completion_len = np.array([float(len(i)) for i in doc["choices"]])
+        acc_norm = 1.0 if np.argmax(results / completion_len) == gold else 0.0
+
+        return {
+            "acc": acc,
+            "acc_norm": acc_norm,
+            "balanced_acc": (acc, gold)
+        }
+
+    def higher_is_better(self):
+        return {
+            "acc": True,
+            "acc_norm": True,
+            "balanced_acc": True,
+        }
+
+    def aggregation(self):
+        return {
+            "acc": mean,
+            "acc_norm": mean,
+            "balanced_acc": balanced_mean,
+        }
+
 
 
 class PerplexityTask(Task, abc.ABC):

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn.functional as F
 
 from lm_eval.metrics import mean, weighted_perplexity, weighted_mean, bits_per_byte
-from lm_eval.metrics import balanced_mean
+from lm_eval.metrics import balanced_mean, matthews_corrcoef, macro_f1
 from lm_eval import utils
 from abc import abstractmethod
 
@@ -721,6 +721,7 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
     def process_results(self, doc, results):
         gold = doc["gold"]
 
+        pred = np.argmax(results)
         acc = 1.0 if np.argmax(results) == gold else 0.0
         completion_len = np.array([float(len(i)) for i in doc["choices"]])
         acc_norm = 1.0 if np.argmax(results / completion_len) == gold else 0.0
@@ -728,7 +729,9 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
         return {
             "acc": acc,
             "acc_norm": acc_norm,
-            "balanced_acc": (acc, gold)
+            "balanced_acc": (acc, gold),
+            "mcc": (gold, pred),
+            "macro_f1": (gold, pred),
         }
 
     def higher_is_better(self):
@@ -736,6 +739,8 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
             "acc": True,
             "acc_norm": True,
             "balanced_acc": True,
+            "mcc": True,
+            "macro_f1": True,
         }
 
     def aggregation(self):
@@ -743,6 +748,8 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
             "acc": mean,
             "acc_norm": mean,
             "balanced_acc": balanced_mean,
+            "mcc": matthews_corrcoef,
+            "macro_f1": macro_f1,
         }
 
 

--- a/lm_eval/metrics.py
+++ b/lm_eval/metrics.py
@@ -62,6 +62,16 @@ def f1_score(items):
     return np.max(fscore)
 
 
+def macro_f1(items):
+    # this is different from f1-score which uses default binary avg
+    unzipped_list = list(zip(*items))
+    golds = unzipped_list[0]
+    preds = unzipped_list[1]
+    fscore = sklearn.metrics.f1_score(golds, preds, average="macro")
+
+    return fscore
+
+
 def acc_all(items):
     # Only count as correct if all answers are labeled correctly for each question
     question_scoring_dict = {}

--- a/lm_eval/metrics.py
+++ b/lm_eval/metrics.py
@@ -5,6 +5,7 @@ import numpy as np
 import sacrebleu
 import sklearn.metrics
 import random
+from collections import defaultdict
 
 
 def mean(arr):
@@ -27,6 +28,22 @@ def mean_stderr(arr):
 
 def median(arr):
     return arr[len(arr) // 2]
+
+
+def balanced_mean(arr):
+    # each entry is of the form (acc score, class label)
+    # first group the results
+    by_class = defaultdict(list)
+    for acc, label in arr:
+        by_class[label].append(acc)
+
+    # calculate class averages
+    avgs = []
+    for key, vals in by_class.items():
+        avgs.append(sum(vals) / len(vals))
+
+    # average the class values
+    return sum(avgs) / len(avgs)
 
 
 def matthews_corrcoef(items):

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -7,7 +7,7 @@ JGLUE has been constructed from scratch without translation.
 
 Homepage: https://github.com/yahoojapan/JGLUE
 """
-from lm_eval.base import MultipleChoiceTask, rf
+from lm_eval.base import BalancedMultipleChoiceTask, rf
 
 _CITATION = """
 @inproceedings{kurihara-etal-2022-jglue,
@@ -28,7 +28,7 @@ _CITATION = """
 
 
 
-class JNLIWithFintanPrompt(MultipleChoiceTask):
+class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
     """
     prompt template is taken from [ChatGPT vs BERT: どちらが日本語をより理解できるのか?](https://fintan.jp/page/9126/)
     """

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -7,7 +7,7 @@ JGLUE has been constructed from scratch without translation.
 
 Homepage: https://github.com/yahoojapan/JGLUE
 """
-from lm_eval.base import MultipleChoiceTask, rf
+from lm_eval.base import BalancedMultipleChoiceTask, rf
 
 _CITATION = """
 @inproceedings{kurihara-etal-2022-jglue,
@@ -28,7 +28,7 @@ _CITATION = """
 
 
 
-class MARCJaWithFintanPrompt(MultipleChoiceTask):
+class MARCJaWithFintanPrompt(BalancedMultipleChoiceTask):
     """
     prompt template is taken from [ChatGPT vs BERT: どちらが日本語をより理解できるのか?](https://fintan.jp/page/9126/)
     """


### PR DESCRIPTION
This adds a "balanced accuracy" metric and uses it to calculate scores for marc-ja and jnli. Specifically, it calculates the accuracy separately by class, then takes the average of those scores, weighted equally. This is important for very imbalanced datasets - mainly marc. 

There may be other better metrics, but this is an improvement over the normal accuracy at the very least.