### PR TITLE
Add option to get response for balanced multiple choice questions

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -740,10 +740,10 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
             "balanced_acc": (acc, gold),
             "mcc": (gold, pred),
             "macro_f1": (gold, pred),
-                "details": {
-                    "question": self.doc_to_text(doc),
-                    "response": response,
-                }
+            "details": {
+                "question": self.doc_to_text(doc),
+                "response": response,
+            },
         }
 
     def higher_is_better(self):

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -696,6 +696,9 @@ class MultipleChoiceTask(Task):
         return {
             "acc": acc,
             "acc_norm": acc_norm,
+            "details": {
+                "scores": results,
+            },
         }
 
     def higher_is_better(self):
@@ -743,6 +746,7 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
             "details": {
                 "question": self.doc_to_text(doc),
                 "response": response,
+                "scores": results,
             },
         }
 

--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -723,6 +723,12 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
     def process_results(self, doc, results):
         gold = doc["gold"]
 
+        # This isn't very clean, but it may be the best we can do since lm ops
+        # are submitted as an iterator for batching
+        response = None
+        if isinstance(results[-1], str):
+            response = results.pop()
+
         pred = np.argmax(results)
         acc = 1.0 if np.argmax(results) == gold else 0.0
         completion_len = np.array([float(len(i)) for i in doc["choices"]])
@@ -734,6 +740,10 @@ class BalancedMultipleChoiceTask(MultipleChoiceTask):
             "balanced_acc": (acc, gold),
             "mcc": (gold, pred),
             "macro_f1": (gold, pred),
+                "details": {
+                    "question": self.doc_to_text(doc),
+                    "response": response,
+                }
         }
 
     def higher_is_better(self):

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -8,6 +8,7 @@ JGLUE has been constructed from scratch without translation.
 Homepage: https://github.com/yahoojapan/JGLUE
 """
 from lm_eval.base import BalancedMultipleChoiceTask, rf
+import os
 
 _CITATION = """
 @inproceedings{kurihara-etal-2022-jglue,
@@ -87,7 +88,8 @@ class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
             rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
         ]
         # this is only used for error analysis
-        lls.append(rf.greedy_until(ctx, [self.SEP]))
+        if os.environ.get('DEBUG_MULTIPLECHOICE'):
+            lls.append(rf.greedy_until(ctx, [self.SEP]))
         return lls
 
 

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -88,7 +88,7 @@ class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
             rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
         ]
         # this is only used for error analysis
-        if os.environ.get('DEBUG_MULTIPLECHOICE'):
+        if os.environ.get("DEBUG_MULTIPLECHOICE"):
             lls.append(rf.greedy_until(ctx, [self.SEP]))
         return lls
 

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -44,6 +44,7 @@ class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
         + "- そのいずれでもない場合はneutralと出力\n\n"
     )
     CHOICES = ["entailment", "contradiction", "neutral"]
+    SEP = "\n"
 
     def has_training_docs(self):
         return True
@@ -85,6 +86,8 @@ class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
         lls = [
             rf.loglikelihood(ctx, "{}".format(choice))[0] for choice in doc["choices"]
         ]
+        # this is only used for error analysis
+        lls.append(rf.greedy_until(ctx, [self.SEP]))
         return lls
 
 

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -38,6 +38,7 @@ class MARCJaWithFintanPrompt(BalancedMultipleChoiceTask):
     DATASET_NAME = "MARC-ja"
     DESCRIPTION = "製品レビューをnegativeかpositiveのいずれかのセンチメントに分類してください。出力は小文字化してください。 \n\n"
     CHOICES = ["positive", "negative"]
+    SEP = "\n"
 
     def has_training_docs(self):
         return True
@@ -79,7 +80,7 @@ class MARCJaWithFintanPrompt(BalancedMultipleChoiceTask):
         ]
 
         # this is only used for error analysis
-        # lls.append(rf.greedy_until(ctx, [self.SEP]))
+        lls.append(rf.greedy_until(ctx, [self.SEP]))
 
         return lls
 

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -81,7 +81,7 @@ class MARCJaWithFintanPrompt(BalancedMultipleChoiceTask):
         ]
 
         # this is only used for error analysis
-        if os.environ.get('DEBUG_MULTIPLECHOICE'):
+        if os.environ.get("DEBUG_MULTIPLECHOICE"):
             lls.append(rf.greedy_until(ctx, [self.SEP]))
 
         return lls

--- a/lm_eval/tasks/ja/marc_ja.py
+++ b/lm_eval/tasks/ja/marc_ja.py
@@ -8,6 +8,7 @@ JGLUE has been constructed from scratch without translation.
 Homepage: https://github.com/yahoojapan/JGLUE
 """
 from lm_eval.base import BalancedMultipleChoiceTask, rf
+import os
 
 _CITATION = """
 @inproceedings{kurihara-etal-2022-jglue,
@@ -80,7 +81,8 @@ class MARCJaWithFintanPrompt(BalancedMultipleChoiceTask):
         ]
 
         # this is only used for error analysis
-        lls.append(rf.greedy_until(ctx, [self.SEP]))
+        if os.environ.get('DEBUG_MULTIPLECHOICE'):
+            lls.append(rf.greedy_until(ctx, [self.SEP]))
 
         return lls
 


### PR DESCRIPTION
Balanced multiple choice questions use log likelihood estimates and don't actually generate responses to their input. However, generating responses may be useful for debugging. This adds the option to generate responses that will be visible in verbose output.

A problem with this is that individual tasks have no way of knowing if they are being run in verbose mode or not, and doing generation is pretty expensive/slow. I am not sure if there's a good way to work around that. A quick hack would be to use an environment variable. 

I will think about how to improve this for a bit before we merge it.