### PR TITLE
Add autoGPTQ installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pip install -e ".[multilingual]"
 To support loading GPTQ quantized models, install the package with the `auto-gptq` extra:
 
 ```bash
+pip install gekko
 pip install -e ".[auto-gptq]"
 ```
 


### PR DESCRIPTION
I noticed that the installation of gptq sometimes fails.  
If you do not manually install gekko, the autoGPTQ installation may fail.  
Even if you modify setup.py, it will fail because autoGPTQ installation is executed first.  

You can check the behavior below.  
[Stability_AI_lm_evaluation_harness_gptq_example](https://github.com/webbigdata-jp/python_sample/blob/main/Stability_AI_lm_evaluation_harness_gptq_example.ipynb)
