### PR TITLE
JRD-95 Implement "string contains" approach for jaqket_v2 and jsquad

### DIFF
--- a/lm_eval/jasquad/evaluate.py
+++ b/lm_eval/jasquad/evaluate.py
@@ -60,6 +60,10 @@ def f1_score(prediction, ground_truth):
     return f1
 
 
+def contains_score(prediction, ground_truth):
+    return normalize_answer(ground_truth) in normalize_answer(prediction)
+
+
 def exact_match_score(prediction, ground_truth):
     return normalize_answer(prediction) == normalize_answer(ground_truth)
 
@@ -73,7 +77,7 @@ def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
 
 
 def evaluate(dataset, predictions):
-    f1 = exact_match = total = 0
+    f1 = exact_match = contains = total = 0
     for article in dataset:
         for paragraph in article["paragraphs"]:
             for qa in paragraph["qas"]:
@@ -89,12 +93,16 @@ def evaluate(dataset, predictions):
                 exact_match += metric_max_over_ground_truths(
                     exact_match_score, prediction, ground_truths
                 )
+                contains += metric_max_over_ground_truths(
+                    contains_score, prediction, ground_truths
+                )
                 f1 += metric_max_over_ground_truths(f1_score, prediction, ground_truths)
 
     exact_match = 100.0 * exact_match / total
+    contains = 100.0 * contains / total
     f1 = 100.0 * f1 / total
 
-    return {"exact_match": exact_match, "f1": f1}
+    return {"exact_match": exact_match, "contains": contains, "f1": f1}
 
 
 if __name__ == "__main__":

--- a/lm_eval/tasks/ja/jaqket_v2.py
+++ b/lm_eval/tasks/ja/jaqket_v2.py
@@ -279,6 +279,10 @@ class JAQKETV2(Task):
                 predictions,
                 references,
             ),  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": (
+                predictions,
+                references,
+            ),  # String contains (the normalized answer contains the normalized gold answer)
             "f1": (
                 predictions,
                 references,
@@ -300,6 +304,9 @@ class JAQKETV2(Task):
             "exact_match": partial(
                 self._squad_agg, "exact_match"
             ),  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": partial(
+                self._squad_agg, "contains"
+            ),  # String contains (the normalized answer contains the normalized gold answer)
             "f1": partial(
                 self._squad_agg, "f1"
             ),  # The F-score of predicted tokens versus the gold answer
@@ -308,6 +315,7 @@ class JAQKETV2(Task):
     def higher_is_better(self):
         return {
             "exact_match": True,  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": True,  # String contains (the normalized answer contains the normalized gold answer)
             "f1": True,  # The F-score of predicted tokens versus the gold answer
         }
 

--- a/lm_eval/tasks/ja/jsquad.py
+++ b/lm_eval/tasks/ja/jsquad.py
@@ -156,6 +156,10 @@ class JSQuAD(Task):
                 predictions,
                 references,
             ),  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": (
+                predictions,
+                references,
+            ),  # String contains (the normalized answer contains the normalized gold answer)
             "f1": (
                 predictions,
                 references,
@@ -176,6 +180,9 @@ class JSQuAD(Task):
             "exact_match": partial(
                 self._squad_agg, "exact_match"
             ),  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": partial(
+                self._squad_agg, "contains"
+            ),  # String contains (the normalized answer contains the normalized gold answer)
             "f1": partial(
                 self._squad_agg, "f1"
             ),  # The F-score of predicted tokens versus the gold answer
@@ -184,6 +191,7 @@ class JSQuAD(Task):
     def higher_is_better(self):
         return {
             "exact_match": True,  # Exact match (the normalized answer exactly match the gold answer)
+            "contains": True,  # String contains (the normalized answer contains the normalized gold answer)
             "f1": True,  # The F-score of predicted tokens versus the gold answer
         }
 


### PR DESCRIPTION
LLMs can sometimes provide correct answers but that may not be an exact match to the ground truth.
In order to account for this, in addition to the existing "exact match" approach, this PR adds a new "string contains" approach. For example, this is done by LINE corporation (https://logmi.jp/tech/articles/325454): 

> 正解かどうかの判定は、出力結果の一部に正解が内包されているかどうかで判定しています。


