### PR TITLE
Use Japanese prompt instead of English for JNLI

### DIFF
--- a/docs/jptasks.md
+++ b/docs/jptasks.md
@@ -30,7 +30,7 @@ python main.py \
 ```
 
 ### JNLI
-> JNLI is a Japanese version of the NLI (Natural Language Inference) dataset. NLI is a task to recognize the inference relation that a premise sentence has to a hypothesis sentence. The inference relations are `entailment`, `contradiction`, and `neutral`.
+> JNLI is a Japanese version of the NLI (Natural Language Inference) dataset. NLI is a task to recognize the inference relation that a premise sentence has to a hypothesis sentence. The inference relations are `含意`, `矛盾`, and `中立`.
 
 **sample script**
 ```

--- a/lm_eval/tasks/ja/jnli.py
+++ b/lm_eval/tasks/ja/jnli.py
@@ -33,18 +33,18 @@ class JNLIWithFintanPrompt(BalancedMultipleChoiceTask):
     prompt template is taken from [ChatGPT vs BERT: どちらが日本語をより理解できるのか?](https://fintan.jp/page/9126/)
     """
 
-    VERSION = 1.1
+    VERSION = 1.2
     PROMPT_VERSION = 0.2
     DATASET_PATH = "shunk031/JGLUE"
     DATASET_NAME = "JNLI"
     DESCRIPTION = (
-        "前提と仮説の関係をentailment、contradiction、neutralの中から回答してください。\n\n"
+        "前提と仮説の関係を含意、矛盾、中立の中から回答してください。\n\n"
         + "制約:\n"
-        + "- 前提から仮説が、論理的知識や常識的知識を用いて導出可能である場合はentailmentと出力\n"
-        + "- 前提と仮説が両立しえない場合はcontradictionと出力\n"
-        + "- そのいずれでもない場合はneutralと出力\n\n"
+        + "- 前提から仮説が、論理的知識や常識的知識を用いて導出可能である場合は含意と出力\n"
+        + "- 前提と仮説が両立しえない場合は矛盾と出力\n"
+        + "- そのいずれでもない場合は中立と出力\n\n"
     )
-    CHOICES = ["entailment", "contradiction", "neutral"]
+    CHOICES = ["含意", "矛盾", "中立"]
     SEP = "\n"
 
     def has_training_docs(self):
@@ -187,9 +187,9 @@ class JNLIWithLlama2(JNLIWithJAAlpacaPrompt):
         与えられた前提と仮説の関係を回答してください。
 
         出力は以下から選択してください：
-        entailment
-        contradiction
-        neutral
+        含意
+        矛盾
+        中立
 
         前提：{premise}
         仮説：{hypothesis} [/INST]


### PR DESCRIPTION
# Overview

This PR replaces the English words `entailment`, `contradiction`, and `neutral` in the prompt for the JNLI task with the Japanese words `含意`, `矛盾`, and `中立`. The purpose behind this is to guarantee that we evaluate the Japanese capability of the language models (and not necessarily English capabilities).

Note that the task version has been bumped from 1.1 to 1.2, since this modifies the task definition.

# Details

The following table shows the balanced accuracy for JNLI across several models.
As shown, prior to this PR, many models have a score of 33.33, which is essentially the same as random chance (given that there are 3 classes to choose from). After this PR, none of the models have a score of 33.33.

<img width="789" alt="image" src="https://github.com/Stability-AI/lm-evaluation-harness/assets/128211/d37d7ae5-7a5b-4f6f-a7a1-b05b082abc99">
