### PR TITLE
need additional_special_tokens argument for HFLM initializer

### DIFF
--- a/lm_eval/models/gpt2.py
+++ b/lm_eval/models/gpt2.py
@@ -19,6 +19,7 @@ class HFLM(BaseLM):
         load_in_8bit: Optional[bool] = False,
         trust_remote_code: Optional[bool] = False,
         use_fast: Optional[bool] = True,
+        additional_special_tokens: Optional[str] = None,
     ):
         super().__init__()
 
@@ -64,6 +65,7 @@ class HFLM(BaseLM):
             revision=revision,
             trust_remote_code=trust_remote_code,
             use_fast=use_fast,
+            additional_special_tokens=additional_special_tokens,
         )
         self.vocab_size = self.tokenizer.vocab_size
 


### PR DESCRIPTION
[the model card](https://huggingface.co/stabilityai/japanese-stablelm-base-alpha-7b) says that we have to pass `additional_special_tokens` arg to the tokenizer. but, we cannot pass that to HFLM initializer for now.

in this PR, I added `additional_special_tokens`  to HFLM initializer.